### PR TITLE
Add extensibility stack, switch to Gemma 4, consolidate model set

### DIFF
--- a/local-llm/5090-model-evaluation.md
+++ b/local-llm/5090-model-evaluation.md
@@ -1,0 +1,393 @@
+# RTX 5090 Model Evaluation Plan
+
+## Purpose
+
+This is a standalone prompt/plan for evaluating model options after upgrading the
+Windows workstation GPU from RTX 4090 (24 GB) to RTX 5090 (32 GB). The additional
+8 GB VRAM unlocks models and context lengths that don't fit on the 4090.
+
+Any model change validated here applies to **both** the local Windows workstation
+and the CachyOS server profile (which also runs an RTX 4090 today and may be
+upgraded in the future).
+
+---
+
+## Current State (Pre-Upgrade Baseline)
+
+### Hardware
+| Host | GPU | VRAM | Role |
+|------|-----|------|------|
+| Windows workstation | RTX 4090 → **RTX 5090** | 24 GB → **32 GB** | Desktop, primary dev |
+| CachyOS server (squire) | RTX 4090 | 24 GB | Headless inference server |
+
+### Software Stack
+- **Backend**: Ollama (with vendored llama.cpp)
+- **Frontend**: Crush CLI (task profiles), Copilot CLI (legacy scripts)
+- **MCP servers**: docx-mcp-server (Word), ppt-mcp (PowerPoint), FLUX.1 (image gen)
+- **Env vars**: `OLLAMA_FLASH_ATTENTION=1`, `OLLAMA_KV_CACHE_TYPE=q8_0`
+
+### Current Model Set
+| Model | Role | Ollama Tag | Custom Model | num_ctx | Measured VRAM | GPU % |
+|-------|------|-----------|-------------|---------|---------------|-------|
+| Gemma 4 26B (MoE, 3.8B active) | Primary (all tasks) | gemma4:26b | gemma4-65k | 65536 | ~21 GB | 100% |
+| Qwen3 14B | Image gen only | qwen3:14b | — | 8192 | ~9 GB | 100% |
+
+### Task Profiles (from crush-task.ps1 / crush-task.sh)
+| Profile | MCP Tools | Tool Token Overhead | Typical Session | Key Capability |
+|---------|-----------|--------------------|--------------------|----------------|
+| Coding | None | 0 | 30-60K tokens (long refactors) | Reasoning, code gen |
+| Word | 54 tools | ~5K | 10-30K tokens | Tool calling accuracy |
+| PowerPoint | 37 tools (short desc) | ~3K | 10-20K tokens | Tool calling accuracy |
+| Image gen | FLUX MCP | ~1K | 4-8K tokens | N/A (uses qwen3:14b) |
+| All tools | 93 tools | ~10-15K | Up to 50K tokens | Tool calling + reasoning |
+
+### Config Files That Change on Model Switch
+- `config/crush.json` — template (models.large, provider model lists)
+- `~/.config/crush/crush.json` — live config
+- `scripts/crush-task.ps1` — `$DefaultModel` variable (line 26)
+- `scripts/crush-task.sh` — `DEFAULT_MODEL` variable (line 55)
+- `scripts/copilot-local.cmd` — ~22 model references
+- `scripts/copilot-local.sh` — ~20 model references
+- `scripts/imagegen-launch.ps1` — default model (line 3)
+- `windows/install-windows.ps1` — model descriptions, profiles, num_ctx mapping
+- `cachyos/install-cachyos.sh` — SELECTED_MODELS, num_ctx mapping, descriptions
+
+---
+
+## RTX 5090 VRAM Budget
+
+| Host | VRAM Total | Baseline Overhead | Available for Model |
+|------|-----------|-------------------|---------------------|
+| Windows workstation (5090) | 32,768 MiB (~32 GB) | ~2 GB (compositor + Ollama) | **~30 GB** |
+| CachyOS server (4090, unchanged) | 24,564 MiB (~24 GB) | ~0.5-1 GB | **~23.5 GB** |
+
+**Critical constraint**: Any model chosen must also work on the CachyOS 4090 server.
+If a model only fits on 5090, it can only be the Windows-local model, and the server
+must keep Gemma 4 26B or another 4090-compatible model. This creates a split
+configuration that should be avoided unless the quality gain is substantial.
+
+---
+
+## Candidate Models to Evaluate
+
+Models are sorted by priority. All sizes are Ollama Q4_K_M unless noted.
+
+### Tier 1: Models Unlocked by 5090 (didn't fit on 4090)
+
+| Model | Arch | Total/Active | Ollama Size | Published Benchmarks | Why Test |
+|-------|------|-------------|-------------|---------------------|----------|
+| **Qwen3.5-35B-A3B** | MoE | 35B/3B | 24 GB | BFCL 67.3%, LiveCode 74.6%, GPQA 84.2%, **TAU2 81.2%** | Highest agentic score; didn't fit on 4090 |
+| **Gemma 4 31B** | Dense | 31B/31B | 20 GB | LiveCode 80.0%, GPQA 84.3%, TAU2 76.9% | Dense reasoning powerhouse |
+| **Qwen3.5-27B** | Hybrid | 27B/27B | 17 GB | **BFCL 68.5%**, **LiveCode 80.7%**, **GPQA 85.5%**, TAU2 79.0% | Best benchmarks, now fits 100% GPU |
+| **Qwen3.5-27B at 128K ctx** | Hybrid | 27B/27B | 17 GB | Same | Same model, double context for long sessions |
+
+### Tier 2: Revalidate with Headroom
+
+| Model | Arch | Total/Active | Ollama Size | Why Test |
+|-------|------|-------------|-------------|----------|
+| **GPT-OSS 20B** | MoE | 21B/3.6B | 14 GB | Most VRAM-efficient; could run 256K context |
+| **Gemma 4 26B at 128K** | MoE | 25B/3.8B | 18 GB | Current model with doubled context window |
+
+### Tier 3: If New Models Have Appeared
+At the time of this evaluation, check:
+- `ollama.com/library` for any new 30-50B models
+- HuggingFace trending models in the 30-50B range
+- r/LocalLLaMA top posts from the last 2 months
+- Any new Qwen, Gemma, GPT-OSS, or Mistral releases
+
+---
+
+## VRAM Fit Projections (5090, 30 GB available)
+
+| Model | Weights | KV@65K q8_0 | Total@65K | Fits 5090? | KV@128K q8_0 | Total@128K | Fits? | KV@256K | Total@256K | Fits? |
+|-------|---------|-------------|-----------|-----------|-------------|-----------|-------|---------|-----------|-------|
+| Qwen3.5-35B-A3B | 24 GB | ~1-2 GB | ~25-26 GB | ✅ +4 GB | ~3-4 GB | ~27-28 GB | ✅ +2 GB | ~6-8 GB | ~30-32 GB | ⚠️ |
+| Gemma 4 31B | 20 GB | ~6-8 GB* | ~26-28 GB | ✅ ~2 GB | ~12-16 GB | ~32-36 GB | ❌ | — | — | ❌ |
+| Qwen3.5-27B | 17 GB | ~2.3 GB | ~19 GB | ✅✅ +11 GB | ~4.3 GB | ~21 GB | ✅✅ | ~8 GB | ~25 GB | ✅ +5 GB |
+| GPT-OSS 20B | 14 GB | ~1 GB | ~15 GB | ✅✅ +15 GB | ~2 GB | ~16 GB | ✅✅ | ~4 GB | ~18 GB | ✅✅ |
+| Gemma 4 26B | 18 GB | ~2 GB | ~20 GB | ✅✅ +10 GB | ~4 GB | ~22 GB | ✅✅ | ~8 GB | ~26 GB | ✅ +4 GB |
+
+\* Gemma 4 31B is dense with ~31B params, so full KV cache per layer.
+Note: Qwen3.5-27B has hybrid attention (16/64 full attention layers), so KV cache is
+~25% of a traditional dense model. Qwen3.5-35B-A3B is MoE with small active params.
+
+### Cross-Host Compatibility Check
+
+| Model | Fits 5090 (30 GB) @65K | Fits 4090 (23.5 GB) @65K | Both Hosts? |
+|-------|----------------------|------------------------|-------------|
+| Qwen3.5-35B-A3B | ✅ | ❌ (24 GB weights alone) | ❌ Windows-only |
+| Gemma 4 31B | ✅ | ❌ (26-28 GB total) | ❌ Windows-only |
+| Qwen3.5-27B | ✅✅ | ⚠️ 28 GB measured, 16% CPU spill | ❌ Windows-only* |
+| GPT-OSS 20B | ✅✅ | ✅✅ | ✅ Both |
+| Gemma 4 26B | ✅✅ | ✅ (verified 100% GPU) | ✅ Both |
+
+\* Qwen3.5-27B was measured at 28 GB loaded / 16% CPU on RTX 4090 (May 2026). Ollama
+may not optimize the hybrid attention KV cache, allocating more than theoretically needed.
+**Re-measure on the 5090** — it should fit 100% GPU with 32 GB VRAM.
+
+---
+
+## Evaluation Procedure
+
+### Prerequisites
+1. RTX 5090 installed and verified (`nvidia-smi` shows 32 GB)
+2. Ollama updated to latest version
+3. Env vars confirmed: `OLLAMA_FLASH_ATTENTION=1`, `OLLAMA_KV_CACHE_TYPE=q8_0`
+4. Benchmark fixtures available in `D:\scratch\copilot-localllm\`:
+   - `bench-test2-buggy.py` (bug fix test)
+   - `bench-test3-complex.py` (code explanation test)
+   - `bench-run.py` (automated benchmark runner)
+
+### Step 1: Baseline Measurement
+```powershell
+# Confirm 5090 VRAM and baseline load
+nvidia-smi --query-gpu=name,memory.total,memory.used,memory.free --format=csv,noheader
+# Confirm Gemma 4 26B still works (regression check)
+ollama run gemma4-65k "Say hello"
+ollama ps
+nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits
+```
+
+### Step 2: Pull Candidate Models
+```powershell
+ollama pull qwen3.5:27b    # 17 GB — Tier 1 priority
+ollama pull qwen3.5:35b    # 24 GB — Tier 1, 5090-only
+ollama pull gemma4:31b     # 20 GB — Tier 1, 5090-only
+ollama pull gpt-oss:20b    # 14 GB — Tier 2
+```
+
+### Step 3: Create Custom Models with Context Windows
+For each candidate, create custom models at multiple context levels:
+```powershell
+# Example for qwen3.5:27b
+echo "FROM qwen3.5:27b`nPARAMETER num_ctx 65536" | Set-Content Modelfile-tmp
+ollama create qwen35-65k -f Modelfile-tmp
+
+echo "FROM qwen3.5:27b`nPARAMETER num_ctx 131072" | Set-Content Modelfile-tmp
+ollama create qwen35-128k -f Modelfile-tmp
+
+# Repeat for each candidate at 65K and 128K (and 256K where viable)
+```
+
+### Step 4: VRAM and GPU Fit Measurement
+For each custom model:
+```powershell
+ollama stop <previous-model>
+Start-Sleep 5
+# Get baseline
+nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits
+
+# Load model
+ollama run <model-name> "What is 2+2?"
+
+# Measure
+ollama ps    # Shows SIZE, PROCESSOR (CPU/GPU split), CONTEXT
+nvidia-smi --query-gpu=memory.used,memory.free --format=csv,noheader,nounits
+```
+
+**Record this data for every model:**
+| Model | num_ctx | Ollama SIZE | CPU/GPU Split | nvidia-smi Used | nvidia-smi Free |
+|-------|---------|-------------|---------------|-----------------|-----------------|
+| (fill in) | | | | | |
+
+**Pass/fail criteria:**
+- ✅ PASS: 100% GPU (0% CPU) — no spill
+- ⚠️ MARGINAL: ≤10% CPU — slight spill, may be acceptable
+- ❌ FAIL: >10% CPU — too much spill, will degrade generation speed
+
+### Step 5: Benchmark Suite
+Update `bench-run.py` MODELS list to include candidates that passed Step 4:
+```python
+MODELS = ["gemma4-65k", "qwen35-65k", "qwen35-128k", ...]  # add passing models
+```
+
+**Important for Qwen3.5 models**: The benchmark script must set `"think": False` in
+the API payload to disable chain-of-thought reasoning. This is already implemented
+in bench-run.py (checks for `"qwen3" in model`).
+
+Run benchmarks:
+```powershell
+cd D:\scratch\copilot-localllm
+python bench-run.py
+```
+
+**Record for each model:**
+| Model | Test 1 (codegen) tok/s | Test 2 (bugfix) tok/s | Test 3 (explain) tok/s | Avg tok/s | Prompt tok/s |
+|-------|----------------------|---------------------|---------------------|-----------|-------------|
+| (fill in) | | | | | |
+
+### Step 6: Tool Calling Validation
+For each candidate that passes speed threshold (≥20 tok/s average):
+1. Create a `.crush.json` with the model name
+2. Run Crush with the coding profile — verify it generates correct tool calls
+3. Run Crush with the Word profile — verify it calls docx-mcp-server tools correctly
+4. Run Crush with the PPTX profile — verify it calls ppt-mcp tools correctly
+
+### Step 7: Long Session Test
+For the top 1-2 candidates:
+1. Start a Crush coding session
+2. Have a 10+ turn conversation about a real codebase
+3. Monitor for compaction events (Crush logs "compacting context" messages)
+4. Note when/if context fills up
+
+---
+
+## Decision Framework
+
+### Speed Threshold
+Based on our experience:
+- **>50 tok/s**: Excellent — feels instant (Gemma 4 26B baseline)
+- **20-50 tok/s**: Good — acceptable for interactive use
+- **10-20 tok/s**: Marginal — noticeable lag, tolerable for high-quality output
+- **<10 tok/s**: Unacceptable — too slow for interactive coding sessions
+
+### Scoring Matrix (weight × score)
+
+| Criterion | Weight | How to Score |
+|-----------|--------|-------------|
+| Generation speed (tok/s) | 25% | >50=5, 35-50=4, 20-35=3, 10-20=2, <10=1 |
+| Coding quality (response correctness) | 25% | Judge from benchmark responses |
+| Tool calling accuracy | 20% | Pass/fail from Step 6 |
+| VRAM fit (100% GPU) | 15% | 100%=5, 95%=4, 90%=3, <90%=1 |
+| Context window achievable | 10% | 256K=5, 128K=4, 65K=3, 32K=2 |
+| License | 5% | Apache 2.0=5, Gemma ToU=3, restrictive=1 |
+
+### Decision Paths
+
+**Path A: Single model, both hosts**
+Best outcome. The chosen model must fit 100% GPU on BOTH the 5090 (Windows) and 4090
+(CachyOS). Models eligible: Gemma 4 26B, GPT-OSS 20B, and any future MoE ≤19 GB.
+
+If a cross-host model wins, update:
+- `crush-task.ps1` `$DefaultModel` (line 26)
+- `crush-task.sh` `DEFAULT_MODEL` (line 55)
+- `config/crush.json` models.large
+- `copilot-local.cmd` and `copilot-local.sh` (all model references)
+- `install-windows.ps1` and `install-cachyos.sh` (model profiles, descriptions)
+- Create custom Ollama model with Modelfile on both hosts
+- Deploy updated scripts to `C:\Users\Jesse\Documents\CLI\` (Windows)
+
+**Path B: Split configuration (5090 model ≠ 4090 model)**
+If a 5090-only model (Qwen3.5-35B, Gemma 4 31B, Qwen3.5-27B) is substantially better:
+- Windows workstation uses the 5090 model
+- CachyOS server keeps Gemma 4 26B (or other 4090-compatible model)
+- `crush.json` squire-server provider keeps its own model list
+- `install-windows.ps1` and `install-cachyos.sh` diverge on model selection
+- `crush-task.ps1` sets `$DefaultModel` to the 5090 model
+- `crush-task.sh` sets `DEFAULT_MODEL` to the 4090 model
+- Complexity cost: two model configs to maintain
+
+**Path C: Keep Gemma 4 26B, just increase context**
+If no candidate beats Gemma 4 on the scoring matrix, use the extra 5090 VRAM for
+a larger context window (128K or 256K) instead of a different model:
+- Create `gemma4-128k` custom model (FROM gemma4:26b, PARAMETER num_ctx 131072)
+- Estimated VRAM at 128K: ~22 GB (fits easily in 30 GB)
+- Update `crush-task.ps1` to use `gemma4-128k` for coding profile
+- Keep `gemma4-65k` for tool-heavy profiles (context is sufficient at 65K)
+
+---
+
+## Reference Data from RTX 4090 Evaluations (May 2026)
+
+### Gemma 4 26B (Current Primary) — Measured on RTX 4090
+
+| Metric | Value |
+|--------|-------|
+| VRAM loaded (65K ctx) | ~21 GB, 100% GPU |
+| Gen speed (avg) | 54-91 tok/s |
+| Prompt processing | 1760-4174 tok/s |
+| Coding score (bench-run.py) | 14/15 |
+| Bug fix test | Completed in 70s |
+| Tool calling | ✅ Correct formatting |
+
+### Qwen3.5-27B — Measured on RTX 4090
+
+| Metric | Value |
+|--------|-------|
+| VRAM loaded (65K ctx) | 28 GB total, 16% CPU / 84% GPU (spills) |
+| nvidia-smi used | 23,315 MiB (737 MiB free) |
+| Gen speed (avg) | 11.5-12.5 tok/s (with think=false) |
+| Prompt processing | 342-880 tok/s |
+| Coding output | Concise, correct, fewer tokens than Gemma 4 |
+| Bug fix test | Completed in 21.5s (but only 241 tokens — very terse) |
+
+**Key takeaway**: On RTX 4090, Qwen3.5-27B spills 16% to CPU and runs at only
+~12 tok/s — below the 20 tok/s minimum threshold. On RTX 5090 with 30 GB
+available, it should fit 100% GPU and run significantly faster. **Re-measuring
+speed on 5090 is critical.**
+
+### GLM-4.7-Flash — Retired, Reference Only
+
+| Metric | Value |
+|--------|-------|
+| Gen speed | 17.3 tok/s (with q8_0 KV fix) |
+| VRAM (65K ctx) | ~23 GB, 89% GPU (after KV cache fix) |
+| Coding score | 10/15 |
+| Bug fix test | Timed out at 180s |
+| Retired because | Slower, lower quality, larger VRAM than Gemma 4 |
+
+### Published Benchmark Comparison
+
+| Model | BFCL-V4 (Tools) | LiveCode v6 (Coding) | GPQA (Reasoning) | TAU2 (Agentic) |
+|-------|----------------|---------------------|-----------------|----------------|
+| Qwen3.5-27B | **68.5%** | **80.7%** | **85.5%** | 79.0% |
+| Qwen3.5-35B-A3B | 67.3% | 74.6% | 84.2% | **81.2%** |
+| Gemma 4 26B | N/A | 77.1% | 82.3% | 68.2% |
+| Gemma 4 31B | N/A | 80.0% | 84.3% | 76.9% |
+| GPT-OSS 20B | N/A | N/A | N/A | N/A |
+
+Sources: Qwen model card (HuggingFace), Google Gemma 4 tech report, OpenAI GPT-OSS
+model card. Community sentiment from r/LocalLLaMA (722K members).
+
+---
+
+## Architecture Notes
+
+### Qwen3.5-27B Hybrid Attention
+From `Qwen/Qwen3.5-27B/config.json` (HuggingFace):
+- 64 layers, `full_attention_interval: 4`
+- 16 full attention layers (standard KV cache per token)
+- 48 linear attention layers (fixed-size state, Mamba-like)
+- Theoretical KV cache ~25% of a standard dense 27B model
+- **However**: Ollama (May 2026) allocated 28 GB total on RTX 4090 — more than the
+  theoretical ~19 GB. This suggests Ollama may not optimize linear attention KV
+  allocation. Check if newer Ollama versions have improved this.
+
+### GPT-OSS 20B MXFP4 Quantization
+- OpenAI trained the model with MXFP4 quantization built into the training process
+- Not a post-hoc quantization — quality should be higher than standard Q4_K_M
+- Ollama supports MXFP4 natively via custom kernels
+- MoE architecture: 21B total, 3.6B active — similar efficiency to Gemma 4 26B
+
+### Ollama Environment
+Ensure these are set before any evaluation:
+```powershell
+# Check
+[System.Environment]::GetEnvironmentVariable("OLLAMA_FLASH_ATTENTION", "User")
+[System.Environment]::GetEnvironmentVariable("OLLAMA_KV_CACHE_TYPE", "User")
+
+# If not set:
+[System.Environment]::SetEnvironmentVariable("OLLAMA_FLASH_ATTENTION", "1", "User")
+[System.Environment]::SetEnvironmentVariable("OLLAMA_KV_CACHE_TYPE", "q8_0", "User")
+# Then restart Ollama
+```
+
+---
+
+## Checklist
+
+- [ ] RTX 5090 installed, nvidia-smi confirms 32 GB
+- [ ] Ollama updated to latest
+- [ ] Env vars confirmed (OLLAMA_FLASH_ATTENTION=1, OLLAMA_KV_CACHE_TYPE=q8_0)
+- [ ] Baseline VRAM measured (no model loaded)
+- [ ] Gemma 4 26B regression check passed
+- [ ] Pulled: qwen3.5:27b, qwen3.5:35b, gemma4:31b, gpt-oss:20b
+- [ ] Created custom models at 65K, 128K, 256K where viable
+- [ ] VRAM measurements recorded for all candidates
+- [ ] bench-run.py executed with passing candidates
+- [ ] Tool calling validated in Crush for top candidates
+- [ ] Long session test completed for top 1-2 candidates
+- [ ] Decision made (Path A, B, or C)
+- [ ] Config files updated per decision path
+- [ ] Scripts deployed to C:\Users\Jesse\Documents\CLI\
+- [ ] CachyOS server updated if applicable (Path A only)

--- a/local-llm/cachyos/install-cachyos.sh
+++ b/local-llm/cachyos/install-cachyos.sh
@@ -147,7 +147,8 @@ model_description() {
         deepseek-r1:32b) printf '%s' 'DeepSeek R1 32B — code review/reasoning, ~19 GB' ;;
         mistral-small3.2:24b) printf '%s' 'Mistral Small 3.2 — docs/creative/office, ~15 GB' ;;
         gemma4:31b) printf '%s' 'Gemma 4 31B — heavy coding (256k ctx), ~20 GB' ;;
-        qwen3:14b) printf '%s' 'Qwen3 14B — light coding (40k ctx), ~9 GB' ;;
+        gemma4:26b) printf '%s' 'Gemma 4 26B MoE — general (256k ctx), ~17 GB' ;;
+        qwen3:14b) printf '%s' 'Qwen3 14B — image gen profile, VRAM-friendly (131k ctx), ~9 GB' ;;
         gemma3:27b) printf '%s' 'Gemma 3 27B — tech docs (128k ctx), ~16 GB' ;;
         llama3.3:70b-instruct-q2_K) printf '%s' 'Llama 3.3 70B Q2 — creative writing, ~26 GB' ;;
         qwen3-coder:30b) printf '%s' 'Qwen3-Coder 30B MoE — heavy coding/office docs (256k ctx), ~19 GB' ;;
@@ -236,7 +237,7 @@ load_effective_model_config() {
                 EFFECTIVE_MODEL_REQUIRED_GB=58
             else
                 # Ollama (full mode, single-user) uses Ollama tags
-                SELECTED_MODELS=("qwen3-coder:30b" "qwen2.5-coder:14b" "deepseek-r1:32b" "mistral-small3.2:24b")
+                SELECTED_MODELS=("gemma4:26b" "qwen3:14b")
             fi
             ;;
     esac
@@ -768,7 +769,9 @@ WantedBy=multi-user.target
                 local_override_path="${local_override_dir}/override.conf"
                 local_override_content="[Service]
 Environment=\"OLLAMA_HOST=${OLLAMA_BIND_HOST}\"
-Environment=\"OLLAMA_KEEP_ALIVE=5m\"\n"
+Environment=\"OLLAMA_KEEP_ALIVE=5m\"
+Environment=\"OLLAMA_FLASH_ATTENTION=1\"
+Environment=\"OLLAMA_KV_CACHE_TYPE=q8_0\"\n"
 
                 if [[ -n "$MODEL_PATH" ]]; then
                     if mkdir -p "$MODEL_PATH" 2>/dev/null || run_privileged mkdir -p "$MODEL_PATH"; then
@@ -785,6 +788,8 @@ Environment=\"OLLAMA_KEEP_ALIVE=5m\"\n"
                     success "Configured Ollama override at $local_override_path"
                     info "OLLAMA_HOST=${OLLAMA_BIND_HOST}"
                     info "OLLAMA_KEEP_ALIVE=5m"
+                    info "OLLAMA_FLASH_ATTENTION=1"
+                    info "OLLAMA_KV_CACHE_TYPE=q8_0"
                     [[ -n "$MODEL_PATH" ]] && info "OLLAMA_MODELS=${MODEL_PATH}"
                 else
                     add_failure "Failed to create the Ollama systemd override."
@@ -825,9 +830,18 @@ Environment=\"OLLAMA_KEEP_ALIVE=5m\"\n"
     info "Crush is the CLI agent. Prefer user-local install; use pacman when available."
     install_crush || true
 
-    step "Create MCP directories"
-    mkdir -p "${AI_TOOLS_DIR}/mcp-word" "${AI_TOOLS_DIR}/mcp-pptx" "$CRUSH_HOME_DIR" "$CRUSH_CONFIG_DIR"
-    success "Created MCP directories under ${AI_TOOLS_DIR}"
+    step "Install MCP tools"
+    info "Installing MCP servers as uv tools (docx-mcp-server). ppt-mcp is Windows-only."
+    if command_exists uv; then
+        if uv tool install docx-mcp-server --python 3.12 >/dev/null 2>&1; then
+            success "docx-mcp-server installed (Word OOXML editing)"
+        else
+            add_warning "Failed to install docx-mcp-server. Run 'uv tool install docx-mcp-server --python 3.12' manually."
+        fi
+    else
+        add_warning "uv not found — cannot install MCP tools. Install uv first."
+    fi
+    mkdir -p "$CRUSH_HOME_DIR" "$CRUSH_CONFIG_DIR"
     success "Prepared Crush config directories: ${CRUSH_HOME_DIR} and ${CRUSH_CONFIG_DIR}"
 
     # ── Deploy Crush configuration ───────────────────────────────────────
@@ -919,6 +933,37 @@ Environment=\"OLLAMA_KEEP_ALIVE=5m\"\n"
         info "Usage: crush-task (from any directory)"
     else
         warn "crush-task script not found at $crush_task_source — skipping."
+    fi
+
+    # ── Deploy Crush skills and MCP servers ─────────────────────────────
+    step "Deploy Crush skills and MCP servers"
+
+    # Deploy plan-mode MCP server
+    local mcp_source_dir="${SCRIPT_DIR}/../config/mcp"
+    local mcp_dest_dir="${CRUSH_CONFIG_DIR}/mcp"
+    if [[ -d "$mcp_source_dir" ]]; then
+        mkdir -p "$mcp_dest_dir"
+        cp -r "$mcp_source_dir"/* "$mcp_dest_dir"/
+        success "Deployed MCP servers to $mcp_dest_dir"
+    fi
+
+    # Deploy local skills from dotFiles
+    local skills_source_dir="${SCRIPT_DIR}/../config/skills"
+    local skills_dest_dir="${CRUSH_CONFIG_DIR}/skills"
+    if [[ -d "$skills_source_dir" ]]; then
+        mkdir -p "$skills_dest_dir"
+        cp -r "$skills_source_dir"/* "$skills_dest_dir"/
+        success "Deployed local skills (plan-mode, git-safety) to $skills_dest_dir"
+    fi
+
+    # Download latest doc-coauthoring skill from anthropics/skills
+    local doc_coauth_dir="${skills_dest_dir}/doc-coauthoring"
+    mkdir -p "$doc_coauth_dir"
+    local doc_coauth_url="https://raw.githubusercontent.com/anthropics/skills/main/skills/doc-coauthoring/SKILL.md"
+    if curl -fsSL "$doc_coauth_url" -o "${doc_coauth_dir}/SKILL.md" 2>/dev/null; then
+        success "Downloaded latest doc-coauthoring skill from anthropics/skills"
+    else
+        warn "Could not download doc-coauthoring skill from GitHub"
     fi
 
     # ── Deploy Copilot CLI MCP configuration ──────────────────────────────
@@ -1047,6 +1092,23 @@ if [[ "$SHOULD_PULL_MODELS" == true ]]; then
                         else
                             add_failure "Model pull failed: $tag"
                         fi
+                    done
+
+                    # Set num_ctx on models (Ollama defaults to 2048)
+                    printf '%b\n' "${COLOR_GRAY}  Setting context window (num_ctx) on models...${COLOR_RESET}"
+                    local -A num_ctx_settings=(
+                        ["gemma4:26b"]=65536
+                        ["qwen3:14b"]=16384
+                    )
+                    for tag in "${!num_ctx_settings[@]}"; do
+                        local ctx="${num_ctx_settings[$tag]}"
+                        local modelfile_tmp
+                        modelfile_tmp="$(mktemp)"
+                        printf 'FROM %s\nPARAMETER num_ctx %s\n' "$tag" "$ctx" > "$modelfile_tmp"
+                        if "$OLLAMA_BIN" create "$tag" -f "$modelfile_tmp" >/dev/null 2>&1; then
+                            info "  $tag → num_ctx $ctx"
+                        fi
+                        rm -f "$modelfile_tmp"
                     done
                 else
                     add_failure "Ollama binary was not found after the API became ready."

--- a/local-llm/config/copilot-mcp-config.json
+++ b/local-llm/config/copilot-mcp-config.json
@@ -3,13 +3,13 @@
     "word-mcp": {
       "tools": ["*"],
       "type": "local",
-      "command": "__LOCALAPPDATA__/ai-tools/mcp-word/__VENV_BIN__/word_mcp_server__EXE__",
-      "args": []
+      "command": "uvx",
+      "args": ["--python", "3.12", "docx-mcp-server"]
     },
     "pptx-mcp": {
       "type": "local",
-      "command": "__LOCALAPPDATA__/ai-tools/mcp-pptx/__VENV_BIN__/ppt_mcp_server__EXE__",
-      "args": [],
+      "command": "uvx",
+      "args": ["ppt-mcp"],
       "tools": ["*"]
     },
     "imagegen-mcp": {

--- a/local-llm/config/crush.json
+++ b/local-llm/config/crush.json
@@ -7,23 +7,16 @@
       "type": "openai",
       "models": [
         {
-          "name": "GLM-4.7-Flash (Heavy coding / Docs / Creative / Office)",
-          "id": "glm-4.7-flash",
-          "context_window": 202752,
+          "name": "Gemma 4 26B (General)",
+          "id": "gemma4-65k",
+          "context_window": 65536,
           "default_max_tokens": 8000,
           "can_reason": true
         },
         {
-          "name": "Qwen2.5-Coder 14B (Light coding)",
-          "id": "qwen2.5-coder:14b",
-          "context_window": 32768,
-          "default_max_tokens": 8000,
-          "can_reason": true
-        },
-        {
-          "name": "DeepSeek R1 32B (Code review)",
-          "id": "deepseek-r1:32b",
-          "context_window": 131072,
+          "name": "Qwen3 14B (Image gen profile — VRAM-friendly)",
+          "id": "qwen3:14b",
+          "context_window": 16384,
           "default_max_tokens": 8000,
           "can_reason": true
         }
@@ -31,35 +24,21 @@
     },
     "squire-server": {
       "name": "Squire Server (CachyOS Linux)",
-      "base_url": "http://__VLLM_SERVER_IP__:8000/v1/",
+      "base_url": "http://__SQUIRE_SERVER_IP__:11434/v1/",
       "type": "openai",
       "api_key": "unused",
       "models": [
         {
-          "name": "Qwen3-Coder 30B MoE (Heavy coding)",
-          "id": "btbtyler09/Qwen3-Coder-30B-A3B-Instruct-gptq-4bit",
-          "context_window": 262144,
+          "name": "Gemma 4 26B (General)",
+          "id": "gemma4-65k",
+          "context_window": 65536,
           "default_max_tokens": 8000,
           "can_reason": true
         },
         {
-          "name": "Qwen2.5-Coder 14B (Light coding)",
-          "id": "Qwen/Qwen2.5-Coder-14B-Instruct-GPTQ-Int4",
-          "context_window": 32768,
-          "default_max_tokens": 8000,
-          "can_reason": true
-        },
-        {
-          "name": "DeepSeek R1 32B (Code review)",
-          "id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-GPTQ-Int4",
-          "context_window": 131072,
-          "default_max_tokens": 8000,
-          "can_reason": true
-        },
-        {
-          "name": "Mistral Small 3.2 (Docs / Creative / Office)",
-          "id": "mistralai/Mistral-Small-3.2-24B-Instruct-2503-GPTQ-Int4",
-          "context_window": 131072,
+          "name": "Qwen3 14B (Image gen profile — VRAM-friendly)",
+          "id": "qwen3:14b",
+          "context_window": 16384,
           "default_max_tokens": 8000,
           "can_reason": true
         }
@@ -170,12 +149,12 @@
   },
   "models": {
     "large": {
-      "model": "glm-4.7-flash",
+      "model": "gemma4-65k",
       "provider": "ollama",
       "max_tokens": 8000
     },
     "small": {
-      "model": "qwen2.5-coder:14b",
+      "model": "qwen3:14b",
       "provider": "ollama",
       "max_tokens": 8000
     }
@@ -183,13 +162,13 @@
   "mcp": {
     "word-mcp": {
       "type": "stdio",
-      "command": "__LOCALAPPDATA__/ai-tools/mcp-word/__VENV_BIN__/word_mcp_server__EXE__",
-      "args": []
+      "command": "uvx",
+      "args": ["--python", "3.12", "docx-mcp-server"]
     },
     "pptx-mcp": {
       "type": "stdio",
-      "command": "__LOCALAPPDATA__/ai-tools/mcp-pptx/__VENV_BIN__/ppt_mcp_server__EXE__",
-      "args": []
+      "command": "uvx",
+      "args": ["ppt-mcp"]
     },
     "imagegen-mcp": {
       "type": "stdio",
@@ -198,6 +177,31 @@
       "env": {
         "IMAGEGEN_URL": "http://__IMAGEGEN_HOST__:8001"
       }
+    },
+    "planmode": {
+      "type": "stdio",
+      "command": "python__EXE_SUFFIX__",
+      "args": ["__CONFIG_DIR__/mcp/plan_mode_server.py"]
     }
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "bash|edit|write|notebook_edit|mcp__filesystem",
+        "hook": {
+          "type": "command",
+          "command": "python__EXE_SUFFIX__ -c \"import sys; from pathlib import Path; f=Path.home()/'.config'/'crush'/'plan-mode'; sys.exit(2) if f.exists() else sys.exit(0)\"",
+          "timeout_secs": 5
+        }
+      },
+      {
+        "matcher": "mcp__git__(add|commit|push|merge|rebase|reset|stash|checkout_branch|delete_branch|tag|cherry_pick|revert)",
+        "hook": {
+          "type": "command",
+          "command": "python__EXE_SUFFIX__ -c \"import sys; print('Git write operations are blocked by policy.'); sys.exit(2)\"",
+          "timeout_secs": 5
+        }
+      }
+    ]
   }
 }

--- a/local-llm/config/mcp/plan_mode_server.py
+++ b/local-llm/config/mcp/plan_mode_server.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Plan mode MCP server — toggles plan/act mode via a file-based flag.
+
+Exposes three tools: plan_mode_enable, plan_mode_disable, plan_mode_status.
+The toggle file at ~/.config/crush/plan-mode controls the mode state.
+A PreToolUse hook in crush.json checks for this file and blocks write tools.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+TOGGLE_FILE = Path.home() / ".config" / "crush" / "plan-mode"
+TOGGLE_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+SERVER_INFO = {"name": "plan-mode", "version": "1.0.0"}
+
+TOOLS = [
+    {
+        "name": "plan_mode_enable",
+        "description": "Enable plan mode. Blocks all write tools (bash, edit, write). The agent should analyze and suggest without modifying files.",
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "plan_mode_disable",
+        "description": "Disable plan mode (enter act mode). Unblocks all write tools. The agent can now execute changes.",
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "plan_mode_status",
+        "description": "Check whether plan mode is currently enabled or disabled.",
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+]
+
+
+def handle_request(req: dict) -> dict | None:
+    method = req.get("method", "")
+
+    if method == "initialize":
+        return {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {"tools": {}},
+            "serverInfo": SERVER_INFO,
+        }
+
+    if method == "notifications/initialized":
+        return None
+
+    if method == "tools/list":
+        return {"tools": TOOLS}
+
+    if method == "tools/call":
+        tool = (req.get("params") or {}).get("name", "")
+
+        if tool == "plan_mode_enable":
+            TOGGLE_FILE.touch()
+            return {"content": [{"type": "text", "text": "🔒 Plan mode enabled. Write tools are now blocked. Analyze and suggest without making changes."}]}
+
+        if tool == "plan_mode_disable":
+            TOGGLE_FILE.unlink(missing_ok=True)
+            return {"content": [{"type": "text", "text": "🔓 Act mode enabled. Write tools are now unblocked. You may proceed with implementation."}]}
+
+        if tool == "plan_mode_status":
+            if TOGGLE_FILE.exists():
+                return {"content": [{"type": "text", "text": "🔒 Plan mode is ACTIVE. Write tools are blocked."}]}
+            return {"content": [{"type": "text", "text": "🔓 Act mode is ACTIVE. Write tools are allowed."}]}
+
+        return {"content": [{"type": "text", "text": f"Unknown tool: {tool}"}], "isError": True}
+
+    return {"error": {"code": -32601, "message": f"Method not found: {method}"}}
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+            result = handle_request(req)
+            if result is None:
+                continue
+            response = {"jsonrpc": "2.0", "id": req.get("id"), "result": result}
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+        except Exception as e:
+            response = {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": str(e)}}
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/local-llm/config/pptx-instructions.md
+++ b/local-llm/config/pptx-instructions.md
@@ -1,0 +1,38 @@
+# PowerPoint Editing Guide (ppt-mcp)
+
+ppt-mcp controls a live PowerPoint instance via COM automation (154 tools).
+
+## Workflow
+1. Open file in PowerPoint
+2. `ppt_activate_presentation` (CALL FIRST!)
+3. Edit using tools below
+4. `ppt_save_presentation`
+
+## Essential Tools
+- `ppt_activate_presentation` — lock session to a file (required first step)
+- `ppt_find_replace_text` — find and replace across deck or slide
+- `ppt_set_text` / `ppt_get_text` / `ppt_get_all_text` — text operations
+- `ppt_get_slide_info` / `ppt_list_slides` — inspect structure
+- `ppt_add_slide` / `ppt_delete_slide` — slide management
+- `ppt_save_presentation` / `ppt_save_presentation_as` — save (export to PDF/PNG)
+
+## Advanced Tools
+- **Charts**: `ppt_add_chart` (20+ types: column, bar, line, pie, scatter, area, doughnut, radar) → `ppt_set_chart_data` → `ppt_format_chart`
+- **SmartArt**: `ppt_add_smartart` (Process, Org Chart, Cycle, Funnel, Venn, Timeline) → `ppt_modify_smartart`
+- **Tables**: `ppt_add_table` → `ppt_set_table_data` → `ppt_merge_table_cells` → `ppt_set_table_borders`
+- **Themes**: `ppt_set_theme_colors` (17 presets or auto-generate from brand color)
+- **Animations**: `ppt_add_animation` (50+ effects) → `ppt_set_slide_transition`
+- **Layout**: `ppt_align_shapes`, `ppt_distribute_shapes`, `ppt_merge_shapes`
+- **Icons**: `ppt_add_svg_icon` (2500+ Material Symbols) → `ppt_search_icons`
+- **Typography**: `ppt_check_typography` (auto-fix widow lines, shrunk text)
+
+## Design Principles
+- Set a bold color palette FIRST with `ppt_set_theme_colors` (don't default to blue)
+- Every slide needs a visual element: image, chart, icon, SmartArt, or shape
+- Don't repeat the same layout on consecutive slides
+- Typography: Title 36-44pt bold, Body 14-16pt, Captions 10-12pt
+- Use two-column, icon+text, grid, or half-bleed image layouts for variety
+
+## QA
+After editing, use `ppt_get_slide_preview` on modified slides for visual verification.
+Check for: overlapping elements, text overflow, low-contrast text, misaligned columns.

--- a/local-llm/config/skills/git-safety/SKILL.md
+++ b/local-llm/config/skills/git-safety/SKILL.md
@@ -1,0 +1,39 @@
+# Git Safety
+
+## Rule
+**Never** run git commands that modify repository history or remote state.
+
+## Blocked Commands
+These git operations are **prohibited** — do not attempt them:
+- `git add` — staging changes
+- `git commit` — creating commits
+- `git push` — pushing to remote
+- `git merge` — merging branches
+- `git rebase` — rebasing branches
+- `git reset` — resetting HEAD
+- `git stash` — stashing changes
+- `git checkout -b` — creating branches
+- `git branch -d` / `git branch -D` — deleting branches
+- `git tag` — creating or deleting tags
+- `git cherry-pick` — applying commits from other branches
+- `git revert` — creating revert commits
+
+## Allowed Commands
+These read-only git operations are safe and encouraged:
+- `git status` — check working tree state
+- `git diff` — view changes
+- `git log` — view commit history
+- `git show` — inspect commits
+- `git blame` — view line-level attribution
+- `git branch` (no flags) — list branches
+- `git remote -v` — list remotes
+- `git stash list` — list stashes (read-only)
+- `git checkout <file>` — restore a file to HEAD state (safe — only undoes local edits)
+
+## Why
+The human controls all version control operations. AI assistants analyze code and suggest
+changes but never push, commit, or modify git history. This prevents:
+- Accidental commits of incomplete or incorrect code
+- Force-pushes that could lose work
+- Branch/tag operations that affect team collaboration
+- Merge conflicts created without human review

--- a/local-llm/config/skills/plan-mode/SKILL.md
+++ b/local-llm/config/skills/plan-mode/SKILL.md
@@ -1,0 +1,45 @@
+# Plan/Act Mode
+
+## Overview
+This project uses a Plan/Act mode system with three components:
+1. A **plan-mode MCP server** for toggling (tools: `plan_mode_enable`, `plan_mode_disable`, `plan_mode_status`)
+2. A **PreToolUse hook** that blocks write tools when plan mode is active
+3. This **skill** that defines your behavior in each mode
+
+## How to Toggle
+
+Use the MCP tools — do NOT use bash for toggling:
+- **Enable plan mode:** Call `plan_mode_enable`
+- **Disable plan mode:** Call `plan_mode_disable`
+- **Check current mode:** Call `plan_mode_status`
+
+## Behavior
+
+### When plan mode is active:
+- **DO:** Analyze code, read files, search, discuss approaches, outline changes
+- **DO:** Present proposed changes as diffs or descriptions
+- **DO:** Ask clarifying questions about requirements
+- **DO NOT:** Write files, run bash commands that modify state, or use edit tools
+- **ANNOUNCE:** "🔒 Plan mode is active. I'll analyze and suggest without making changes."
+
+### When act mode is active:
+- **DO:** Execute the agreed-upon plan — write files, run commands, make changes
+- **ANNOUNCE:** "🔓 Act mode is active. Proceeding with implementation."
+
+## User Commands
+
+When the user says any of these, use the corresponding MCP tool:
+- "plan mode", "switch to plan", "plan", "/plan" → call `plan_mode_enable`
+- "act mode", "switch to act", "act", "/act", "go ahead", "implement it" → call `plan_mode_disable`
+- "what mode", "status", "are you in plan mode" → call `plan_mode_status`
+
+## On Session Start
+
+At the beginning of each session, call `plan_mode_status` to check the current mode
+and announce it. This catches cases where the toggle file persists across sessions.
+
+## Notes
+- The hook blocks tools at the infrastructure level — even if you try to write, Crush will prevent it
+- Read-only tools (grep, glob, view, read) are never blocked
+- The MCP toggle tools are never blocked — you can always switch modes
+- MCP tools that read data are not blocked; only `mcp__filesystem` write operations are matched

--- a/local-llm/mcp/setup-mcp-venvs.ps1
+++ b/local-llm/mcp/setup-mcp-venvs.ps1
@@ -1,6 +1,6 @@
-# MCP Venv Setup — Windows
+# MCP Tool Setup — Windows
 #
-# Creates isolated uv virtual environments for each MCP server.
+# Installs MCP servers as uv tools (globally accessible via uvx).
 # Run this AFTER install-windows.ps1 has installed uv and Python.
 #
 # Usage:
@@ -10,38 +10,29 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-$AiToolsRoot = Join-Path $env:LOCALAPPDATA "ai-tools"
-
-$McpServers = @(
-    @{ Name = "mcp-word";    Package = "office-word-mcp-server";        Description = "Word document creation and automation" }
-    @{ Name = "mcp-pptx";    Package = "office-powerpoint-mcp-server";  Description = "PowerPoint presentation creation" }
+$McpTools = @(
+    @{ Package = "ppt-mcp";          Python = $null;  Description = "PowerPoint COM automation (154 tools)" }
+    @{ Package = "docx-mcp-server";  Python = "3.12"; Description = "Word OOXML editing (45 tools)" }
 )
 
-foreach ($server in $McpServers) {
-    $venvPath = Join-Path $AiToolsRoot $server.Name
-    Write-Host "`n── Setting up $($server.Description) ──" -ForegroundColor Cyan
+foreach ($tool in $McpTools) {
+    Write-Host "`n── Installing $($tool.Description) ──" -ForegroundColor Cyan
 
-    if (Test-Path $venvPath) {
-        Write-Host "  Directory exists, updating..." -ForegroundColor Yellow
-    } else {
-        New-Item -ItemType Directory -Path $venvPath -Force | Out-Null
-        Write-Host "  Created $venvPath"
+    $args = @("tool", "install", $tool.Package)
+    if ($tool.Python) {
+        $args += "--python"
+        $args += $tool.Python
     }
 
-    Write-Host "  Initializing uv project..."
-    & uv init --directory $venvPath --no-readme 2>&1 | Out-Null
-
-    Write-Host "  Installing $($server.Package)..."
-    & uv add --directory $venvPath $server.Package
+    & uv @args
 
     if ($LASTEXITCODE -eq 0) {
-        Write-Host "  ✓ $($server.Name) ready" -ForegroundColor Green
+        Write-Host "  ✓ $($tool.Package) ready" -ForegroundColor Green
     } else {
-        Write-Host "  ✗ Failed to install $($server.Package)" -ForegroundColor Red
+        Write-Host "  ✗ Failed to install $($tool.Package)" -ForegroundColor Red
     }
 }
 
 Write-Host "`n── Done ──" -ForegroundColor Cyan
-Write-Host "MCP venvs are at: $AiToolsRoot"
-Write-Host "Update ~/.crush/mcp-servers.json to point to these paths."
-Write-Host "See config/mcp-servers.json for a template."
+Write-Host "MCP tools installed globally via uv. Use 'uvx <tool>' to run."
+Write-Host "Config files point to 'uvx' command — no path changes needed."

--- a/local-llm/mcp/setup-mcp-venvs.sh
+++ b/local-llm/mcp/setup-mcp-venvs.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-# MCP Venv Setup — Linux
+# MCP Tool Setup — Linux
 #
-# Creates isolated uv virtual environments for each MCP server.
+# Installs MCP servers as uv tools (globally accessible via uvx).
 # Run this AFTER install-cachyos.sh has installed uv and Python.
+#
+# Note: ppt-mcp (COM automation) is Windows-only.
+# On Linux, docx-mcp-server handles Word editing; PPTX editing is
+# done on Windows clients connecting to the headless server.
 #
 # Usage:
 #   chmod +x setup-mcp-venvs.sh
@@ -10,33 +14,14 @@
 
 set -euo pipefail
 
-AI_TOOLS_ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/ai-tools"
-
-declare -A MCP_SERVERS=(
-    ["mcp-word"]="office-word-mcp-server"
-    ["mcp-pptx"]="office-powerpoint-mcp-server"
-)
-
-for name in "${!MCP_SERVERS[@]}"; do
-    package="${MCP_SERVERS[$name]}"
-    venv_path="$AI_TOOLS_ROOT/$name"
-    echo ""
-    echo "── Setting up $name ($package) ──"
-
-    mkdir -p "$venv_path"
-
-    echo "  Initializing uv project..."
-    uv init --directory "$venv_path" --no-readme 2>/dev/null || true
-
-    echo "  Installing $package..."
-    if uv add --directory "$venv_path" "$package"; then
-        echo "  ✓ $name ready"
-    else
-        echo "  ✗ Failed to install $package" >&2
-    fi
-done
+echo "── Installing docx-mcp-server (Word OOXML editing, 45 tools) ──"
+if uv tool install docx-mcp-server --python 3.12; then
+    echo "  ✓ docx-mcp-server ready"
+else
+    echo "  ✗ Failed to install docx-mcp-server" >&2
+fi
 
 echo ""
 echo "── Done ──"
-echo "MCP venvs are at: $AI_TOOLS_ROOT"
-echo "Update ~/.crush/mcp-servers.json to point to these paths."
+echo "MCP tools installed globally via uv. Use 'uvx <tool>' to run."
+echo "Note: ppt-mcp (PowerPoint COM) is Windows-only — not installed on Linux."

--- a/local-llm/scripts/copilot-local.cmd
+++ b/local-llm/scripts/copilot-local.cmd
@@ -1,7 +1,6 @@
 @echo off
 setlocal enabledelayedexpansion
 
-set COPILOT_PROVIDER_BASE_URL=http://localhost:11434/v1
 set COPILOT_PROVIDER_MAX_PROMPT_TOKENS=14000
 set COPILOT_PROVIDER_MAX_OUTPUT_TOKENS=8000
 
@@ -22,24 +21,24 @@ if not defined COPILOT_LOCAL_PROFILE set COPILOT_LOCAL_PROFILE=Desktop
 echo.
 if /i "%COPILOT_LOCAL_PROFILE%"=="Server" (
     echo   --- Coding ---
-    echo   [1] Heavy coding        (glm-4.7-flash^)
-    echo   [2] Light coding        (qwen2.5-coder:14b^)
-    echo   [3] Code review         (deepseek-r1:32b^)
+    echo   [1] Heavy coding        (gemma4-65k^)
+    echo   [2] Light coding        (qwen3:14b^)
+    echo   [3] Code review         (gemma4-65k^)
     echo.
     echo   --- Writing ^& Documents ---
-    echo   [4] Technical docs      (glm-4.7-flash^)
-    echo   [5] Creative writing    (glm-4.7-flash^)
-    echo   [6] Office documents    (glm-4.7-flash^)
+    echo   [4] Technical docs      (gemma4-65k^)
+    echo   [5] Creative writing    (gemma4-65k^)
+    echo   [6] Office documents    (gemma4-65k^)
 ) else (
     echo   --- Coding ---
-    echo   [1] Heavy coding        (glm-4.7-flash^)
+    echo   [1] Heavy coding        (gemma4-65k^)
     echo   [2] Light coding        (qwen3:14b^)
-    echo   [3] Code review         (deepseek-r1:32b^)
+    echo   [3] Code review         (gemma4-65k^)
     echo.
     echo   --- Writing ^& Documents ---
-    echo   [4] Technical docs      (glm-4.7-flash^)
-    echo   [5] Creative writing    (glm-4.7-flash^)
-    echo   [6] Office documents    (glm-4.7-flash^)
+    echo   [4] Technical docs      (gemma4-65k^)
+    echo   [5] Creative writing    (gemma4-65k^)
+    echo   [6] Office documents    (gemma4-65k^)
 )
 echo.
 echo   --- Visual ---
@@ -50,22 +49,22 @@ set /p choice="  Select task [1]: "
 if "%choice%"=="" set choice=1
 
 if /i "%COPILOT_LOCAL_PROFILE%"=="Server" (
-    if "%choice%"=="1" set COPILOT_MODEL=glm-4.7-flash
-    if "%choice%"=="2" set COPILOT_MODEL=qwen2.5-coder:14b
-    if "%choice%"=="3" set COPILOT_MODEL=deepseek-r1:32b
-    if "%choice%"=="4" set COPILOT_MODEL=glm-4.7-flash
-    if "%choice%"=="5" set COPILOT_MODEL=glm-4.7-flash
-    if "%choice%"=="6" set COPILOT_MODEL=glm-4.7-flash
-) else (
-    if "%choice%"=="1" set COPILOT_MODEL=glm-4.7-flash
+    if "%choice%"=="1" set COPILOT_MODEL=gemma4-65k
     if "%choice%"=="2" set COPILOT_MODEL=qwen3:14b
-    if "%choice%"=="3" set COPILOT_MODEL=deepseek-r1:32b
-    if "%choice%"=="4" set COPILOT_MODEL=glm-4.7-flash
-    if "%choice%"=="5" set COPILOT_MODEL=glm-4.7-flash
-    if "%choice%"=="6" set COPILOT_MODEL=glm-4.7-flash
+    if "%choice%"=="3" set COPILOT_MODEL=gemma4-65k
+    if "%choice%"=="4" set COPILOT_MODEL=gemma4-65k
+    if "%choice%"=="5" set COPILOT_MODEL=gemma4-65k
+    if "%choice%"=="6" set COPILOT_MODEL=gemma4-65k
+) else (
+    if "%choice%"=="1" set COPILOT_MODEL=gemma4-65k
+    if "%choice%"=="2" set COPILOT_MODEL=qwen3:14b
+    if "%choice%"=="3" set COPILOT_MODEL=gemma4-65k
+    if "%choice%"=="4" set COPILOT_MODEL=gemma4-65k
+    if "%choice%"=="5" set COPILOT_MODEL=gemma4-65k
+    if "%choice%"=="6" set COPILOT_MODEL=gemma4-65k
 )
 
-if "%choice%"=="7" set COPILOT_MODEL=glm-4.7-flash
+if "%choice%"=="7" set COPILOT_MODEL=qwen3:14b
 
 :: Set MCP flags based on task category
 :: Coding (1-3): disable all MCP servers — max context for code
@@ -83,13 +82,20 @@ if "%choice%"=="7" set MCP_FLAGS=--disable-mcp-server word-mcp --disable-mcp-ser
 if not defined COPILOT_MODEL (
     echo   Invalid selection.
     if /i "%COPILOT_LOCAL_PROFILE%"=="Server" (
-        set COPILOT_MODEL=glm-4.7-flash
+        set COPILOT_MODEL=gemma4-65k
     ) else (
-        set COPILOT_MODEL=glm-4.7-flash
+        set COPILOT_MODEL=gemma4-65k
     )
 )
+
+:: Git safety: block git write operations
+set GIT_SAFETY=--deny-tool="shell(git add)" --deny-tool="shell(git commit)" --deny-tool="shell(git push)" --deny-tool="shell(git merge)" --deny-tool="shell(git rebase)" --deny-tool="shell(git reset)" --deny-tool="shell(git stash)" --deny-tool="shell(git cherry-pick)" --deny-tool="shell(git revert)" --deny-tool="shell(git tag)"
+
+:: Set PPTX instructions for doc profiles (6 = Office documents)
+set EXTRA_FLAGS=
+if "%choice%"=="6" set EXTRA_FLAGS=--custom-instructions "D:\personal\dotFiles\local-llm\config\pptx-instructions.md"
 
 :launch
 echo   Using model: %COPILOT_MODEL%
 echo.
-copilot %MCP_FLAGS% %1 %2 %3 %4 %5 %6 %7 %8 %9
+ollama launch copilot --model %COPILOT_MODEL% --yes -- %MCP_FLAGS% %GIT_SAFETY% %EXTRA_FLAGS% %1 %2 %3 %4 %5 %6 %7 %8 %9

--- a/local-llm/scripts/copilot-local.sh
+++ b/local-llm/scripts/copilot-local.sh
@@ -2,16 +2,15 @@
 # copilot-local — Launch GitHub Copilot CLI with local Ollama models
 set -euo pipefail
 
-export COPILOT_PROVIDER_BASE_URL="http://localhost:11434/v1"
 export COPILOT_PROVIDER_MAX_PROMPT_TOKENS=14000
 export COPILOT_PROVIDER_MAX_OUTPUT_TOKENS=8000
 
 # If a model was passed as first argument (contains ':'), use it directly
 if [[ "${1:-}" == *":"* ]]; then
-    export COPILOT_MODEL="$1"
+    COPILOT_MODEL="$1"
     shift
     echo "  Using model: $COPILOT_MODEL"
-    exec copilot "$@"
+    exec ollama launch copilot --model "$COPILOT_MODEL" --yes -- "$@"
 fi
 
 # Detect profile from environment or default to Desktop
@@ -21,23 +20,23 @@ PROFILE="${COPILOT_LOCAL_PROFILE:-Desktop}"
 echo
 echo "  --- Coding ---"
 if [[ "$PROFILE" == "Server" ]]; then
-    echo "  [1] Heavy coding        (glm-4.7-flash)"
-    echo "  [2] Light coding        (qwen2.5-coder:14b)"
-    echo "  [3] Code review         (deepseek-r1:32b)"
-    echo
-    echo "  --- Writing & Documents ---"
-    echo "  [4] Technical docs      (glm-4.7-flash)"
-    echo "  [5] Creative writing    (glm-4.7-flash)"
-    echo "  [6] Office documents    (glm-4.7-flash)"
-else
-    echo "  [1] Heavy coding        (glm-4.7-flash)"
+    echo "  [1] Heavy coding        (gemma4-65k)"
     echo "  [2] Light coding        (qwen3:14b)"
-    echo "  [3] Code review         (deepseek-r1:32b)"
+    echo "  [3] Code review         (gemma4-65k)"
     echo
     echo "  --- Writing & Documents ---"
-    echo "  [4] Technical docs      (glm-4.7-flash)"
-    echo "  [5] Creative writing    (glm-4.7-flash)"
-    echo "  [6] Office documents    (glm-4.7-flash)"
+    echo "  [4] Technical docs      (gemma4-65k)"
+    echo "  [5] Creative writing    (gemma4-65k)"
+    echo "  [6] Office documents    (gemma4-65k)"
+else
+    echo "  [1] Heavy coding        (gemma4-65k)"
+    echo "  [2] Light coding        (qwen3:14b)"
+    echo "  [3] Code review         (gemma4-65k)"
+    echo
+    echo "  --- Writing & Documents ---"
+    echo "  [4] Technical docs      (gemma4-65k)"
+    echo "  [5] Creative writing    (gemma4-65k)"
+    echo "  [6] Office documents    (gemma4-65k)"
 fi
 echo
 echo "  --- Visual ---"
@@ -62,24 +61,40 @@ esac
 
 if [[ "$PROFILE" == "Server" ]]; then
     case "$choice" in
-        1) export COPILOT_MODEL="glm-4.7-flash" ;;
-        2) export COPILOT_MODEL="qwen2.5-coder:14b" ;;
-        3) export COPILOT_MODEL="deepseek-r1:32b" ;;
-        4|5|6) export COPILOT_MODEL="glm-4.7-flash" ;;
-        7) export COPILOT_MODEL="glm-4.7-flash" ;;
-        *) echo "  Invalid. Using glm-4.7-flash"; export COPILOT_MODEL="glm-4.7-flash" ;;
+        1) export COPILOT_MODEL="gemma4-65k" ;;
+        2) export COPILOT_MODEL="qwen3:14b" ;;
+        3) export COPILOT_MODEL="gemma4-65k" ;;
+        4|5|6) export COPILOT_MODEL="gemma4-65k" ;;
+        7) export COPILOT_MODEL="qwen3:14b" ;;
+        *) echo "  Invalid. Using gemma4-65k"; export COPILOT_MODEL="gemma4-65k" ;;
     esac
 else
     case "$choice" in
-        1) export COPILOT_MODEL="glm-4.7-flash" ;;
+        1) export COPILOT_MODEL="gemma4-65k" ;;
         2) export COPILOT_MODEL="qwen3:14b" ;;
-        3) export COPILOT_MODEL="deepseek-r1:32b" ;;
-        4|5|6) export COPILOT_MODEL="glm-4.7-flash" ;;
-        7) export COPILOT_MODEL="glm-4.7-flash" ;;
-        *) echo "  Invalid. Using glm-4.7-flash"; export COPILOT_MODEL="glm-4.7-flash" ;;
+        3) export COPILOT_MODEL="gemma4-65k" ;;
+        4|5|6) export COPILOT_MODEL="gemma4-65k" ;;
+        7) export COPILOT_MODEL="qwen3:14b" ;;
+        *) echo "  Invalid. Using gemma4-65k"; export COPILOT_MODEL="gemma4-65k" ;;
     esac
+fi
+
+# Git safety: block git write operations
+GIT_SAFETY=(
+    --deny-tool='shell(git add)' --deny-tool='shell(git commit)'
+    --deny-tool='shell(git push)' --deny-tool='shell(git merge)'
+    --deny-tool='shell(git rebase)' --deny-tool='shell(git reset)'
+    --deny-tool='shell(git stash)' --deny-tool='shell(git cherry-pick)'
+    --deny-tool='shell(git revert)' --deny-tool='shell(git tag)'
+)
+
+# PPTX instructions for doc profiles
+EXTRA_FLAGS=()
+if [[ "$choice" == "6" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    EXTRA_FLAGS=(--custom-instructions "$SCRIPT_DIR/../config/pptx-instructions.md")
 fi
 
 echo "  Using model: $COPILOT_MODEL"
 echo
-exec copilot "${MCP_FLAGS[@]}" "$@"
+exec ollama launch copilot --model "$COPILOT_MODEL" --yes -- "${MCP_FLAGS[@]}" "${GIT_SAFETY[@]}" "${EXTRA_FLAGS[@]}" "$@"

--- a/local-llm/scripts/crush-task.ps1
+++ b/local-llm/scripts/crush-task.ps1
@@ -8,26 +8,47 @@
     keeping the tool count low so the model can reliably use them all.
 
     Profiles:
-      Coding  — no MCP servers (code tools only)
-      Office  — word-mcp + pptx-mcp (document editing)
-      Image   — imagegen-mcp (image generation)
-      All     — everything enabled (may degrade with smaller models)
+      Coding      — no MCP servers (code tools only)
+      Word        — word-mcp only (Word document editing)
+      PowerPoint  — pptx-mcp only (PowerPoint editing)
+      Image       — imagegen-mcp (image generation)
+      All         — everything enabled (may degrade with smaller models)
 
     The .crush.json is written to the current directory. Crush merges it
     on top of the global config at ~/.config/crush/crush.json.
 #>
 
 param(
-    [ValidateSet("coding", "office", "image", "all")]
+    [ValidateSet("coding", "word", "pptx", "docs", "image", "all")]
     [string]$Task
 )
 
+$DefaultModel = "gemma4-65k"
+
 function Write-CrushConfig {
     param(
-        [hashtable]$McpOverrides
+        [hashtable]$McpOverrides,
+        [string]$SystemPromptPrefix,
+        [string]$Model
     )
     $config = @{ mcp = $McpOverrides }
-    $json = $config | ConvertTo-Json -Depth 4
+    if ($SystemPromptPrefix) {
+        $config["providers"] = @{
+            "ollama" = @{
+                "system_prompt_prefix" = $SystemPromptPrefix
+            }
+        }
+    }
+    if ($Model) {
+        $config["models"] = @{
+            "large" = @{
+                "model" = $Model
+                "provider" = "ollama"
+                "max_tokens" = 8000
+            }
+        }
+    }
+    $json = $config | ConvertTo-Json -Depth 5
     Set-Content -Path ".crush.json" -Value $json -Encoding UTF8
 }
 
@@ -35,19 +56,23 @@ function Write-CrushConfig {
 if (-not $Task) {
     Write-Host ""
     Write-Host "  --- Crush Task Profiles ---"
-    Write-Host "  [1] Coding          (no MCP — fast, all context for code)"
-    Write-Host "  [2] Office docs     (Word + PowerPoint MCP)"
-    Write-Host "  [3] Image gen       (FLUX.1-schnell MCP)"
-    Write-Host "  [4] All tools       (all MCP servers — may be slow)"
+    Write-Host "  [1] Coding          (no MCP - fast, all context for code)"
+    Write-Host "  [2] Word docs       (Word MCP only - 54 tools)"
+    Write-Host "  [3] PowerPoint      (PPTX MCP only - 37 tools)"
+    Write-Host "  [4] Document create (guided co-authoring workflow)"
+    Write-Host "  [5] Image gen       (FLUX.1-schnell MCP)"
+    Write-Host "  [6] All tools       (all MCP servers - may be slow)"
     Write-Host ""
     $choice = Read-Host "  Select profile [1]"
     if (-not $choice) { $choice = "1" }
 
     switch ($choice) {
         "1" { $Task = "coding" }
-        "2" { $Task = "office" }
-        "3" { $Task = "image" }
-        "4" { $Task = "all" }
+        "2" { $Task = "word" }
+        "3" { $Task = "pptx" }
+        "4" { $Task = "docs" }
+        "5" { $Task = "image" }
+        "6" { $Task = "all" }
         default {
             Write-Host "  Invalid selection, defaulting to coding."
             $Task = "coding"
@@ -57,36 +82,119 @@ if (-not $Task) {
 
 switch ($Task) {
     "coding" {
-        Write-CrushConfig @{
+        Write-CrushConfig -McpOverrides @{
             "word-mcp"     = @{ disabled = $true }
             "pptx-mcp"     = @{ disabled = $true }
             "imagegen-mcp" = @{ disabled = $true }
-        }
+        } -Model $DefaultModel
         Write-Host "  Profile: Coding (no MCP servers)"
     }
-    "office" {
-        Write-CrushConfig @{
+    "word" {
+        $wordGuide = @"
+docx-mcp-server Tool Guide:
+This server edits Word documents via direct OOXML manipulation. Key tools:
+- Open/create documents, then edit with tracked changes visible in Word
+- search_and_replace: Find and replace text
+- add_paragraph / add_heading / add_table: Add content
+- format_text: Apply formatting
+- Supports footnotes, endnotes, comments, headers/footers, sections
+- All edits create real tracked changes (visible in Word's Review tab)
+"@
+        Write-CrushConfig -McpOverrides @{
             "word-mcp"     = @{ disabled = $false }
+            "pptx-mcp"     = @{ disabled = $true }
+            "imagegen-mcp" = @{ disabled = $true }
+        } -SystemPromptPrefix $wordGuide -Model $DefaultModel
+        Write-Host "  Profile: Word (docx-mcp-server, 45 tools)"
+    }
+    "pptx" {
+        $env:CRUSH_SHORT_TOOL_DESCRIPTIONS = "1"
+        $pptxGuide = @"
+IMPORTANT: Be concise. Do not explain what you will do — just do it. Minimize output.
+
+ppt-mcp controls a live PowerPoint instance via COM automation (154 tools).
+
+WORKFLOW: Open file in PowerPoint → ppt_activate_presentation → edit → ppt_save_presentation
+
+ESSENTIAL TOOLS:
+- ppt_activate_presentation (CALL FIRST after opening a file!)
+- ppt_find_replace_text, ppt_set_text, ppt_get_text, ppt_get_all_text
+- ppt_get_slide_info, ppt_list_slides, ppt_add_slide, ppt_delete_slide
+- ppt_save_presentation, ppt_save_presentation_as (export to PDF/PNG)
+
+ADVANCED TOOLS (use these for professional results):
+- Charts: ppt_add_chart (20+ types: column, bar, line, pie, scatter, area, doughnut, radar)
+  → ppt_set_chart_data → ppt_format_chart
+- SmartArt: ppt_add_smartart (any layout: Process, Org Chart, Cycle, Funnel, Venn, Timeline)
+  → ppt_modify_smartart (set_text, add_node, change_layout, change_color)
+- Tables: ppt_add_table → ppt_set_table_data (batch write) → ppt_merge_table_cells
+  → ppt_set_table_borders → ppt_set_table_style
+- Themes: ppt_set_theme_colors (17 presets: corporate_blue, executive, nord_light, etc.
+  OR auto-generate harmonious palette from one brand color)
+- Animations: ppt_add_animation (entrance/exit/emphasis/motion path, 50+ effects)
+  → ppt_set_slide_transition (fade, push, wipe, dissolve)
+- Layout: ppt_align_shapes, ppt_distribute_shapes, ppt_merge_shapes (boolean ops)
+- Icons: ppt_add_svg_icon (2500+ Material Symbols) → ppt_search_icons to find by keyword
+- Typography: ppt_check_typography (auto-fix widow lines, shrunk text)
+
+DESIGN PRINCIPLES:
+- Set a bold color palette FIRST with ppt_set_theme_colors (don't default to blue)
+- Every slide needs a visual element: image, chart, icon, SmartArt, or shape
+- Don't repeat the same layout on consecutive slides
+- Typography: Title 36-44pt bold, Body 14-16pt, Captions 10-12pt
+- Use two-column, icon+text, grid, or half-bleed image layouts for variety
+
+QA: After editing, use ppt_get_slide_preview on modified slides to verify visually.
+Check for: overlapping elements, text overflow, low-contrast text, misaligned columns.
+"@
+        Write-CrushConfig -McpOverrides @{
+            "word-mcp"     = @{ disabled = $true }
             "pptx-mcp"     = @{ disabled = $false }
             "imagegen-mcp" = @{ disabled = $true }
+        } -SystemPromptPrefix $pptxGuide -Model $DefaultModel
+        Write-Host "  Profile: PowerPoint (ppt-mcp COM, 154 tools, short descriptions)"
+    }
+    "docs" {
+        # Download latest doc-coauthoring skill in background
+        $docSkillDir = Join-Path $env:USERPROFILE ".config\crush\skills\doc-coauthoring"
+        $docSkillFile = Join-Path $docSkillDir "SKILL.md"
+        Start-Job -ScriptBlock {
+            param($dir, $file)
+            try {
+                if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+                Invoke-WebRequest -Uri "https://raw.githubusercontent.com/anthropics/skills/main/skills/doc-coauthoring/SKILL.md" `
+                    -OutFile $file -TimeoutSec 5 -ErrorAction Stop
+            } catch {}
+        } -ArgumentList $docSkillDir, $docSkillFile | Out-Null
+
+        # Load skill content into system prompt if available
+        $docsGuide = "You are a document co-authoring assistant. Guide the user through structured document creation."
+        if (Test-Path $docSkillFile) {
+            $docsGuide = Get-Content $docSkillFile -Raw
         }
-        Write-Host "  Profile: Office (Word + PowerPoint)"
+        Write-CrushConfig -McpOverrides @{
+            "word-mcp"     = @{ disabled = $false }
+            "pptx-mcp"     = @{ disabled = $true }
+            "imagegen-mcp" = @{ disabled = $true }
+        } -SystemPromptPrefix $docsGuide -Model $DefaultModel
+        Write-Host "  Profile: Document creation (doc-coauthoring skill + Word MCP)"
     }
     "image" {
-        Write-CrushConfig @{
+        Write-CrushConfig -McpOverrides @{
             "word-mcp"     = @{ disabled = $true }
             "pptx-mcp"     = @{ disabled = $true }
             "imagegen-mcp" = @{ disabled = $false }
-        }
-        Write-Host "  Profile: Image generation (FLUX.1-schnell)"
+        } -Model "qwen3:14b"
+        Write-Host "  Profile: Image generation (FLUX.1-schnell) — using qwen3:14b for VRAM headroom"
     }
     "all" {
-        Write-CrushConfig @{
+        $env:CRUSH_SHORT_TOOL_DESCRIPTIONS = "1"
+        Write-CrushConfig -McpOverrides @{
             "word-mcp"     = @{ disabled = $false }
             "pptx-mcp"     = @{ disabled = $false }
             "imagegen-mcp" = @{ disabled = $false }
-        }
-        Write-Host "  Profile: All tools (93 MCP tools — may be slow with smaller models)"
+        } -Model $DefaultModel
+        Write-Host "  Profile: All tools (93 MCP tools - may be slow with smaller models)"
     }
 }
 

--- a/local-llm/scripts/crush-task.sh
+++ b/local-llm/scripts/crush-task.sh
@@ -6,7 +6,8 @@
 #
 # Profiles:
 #   coding  — no MCP servers (code tools only)
-#   office  — word-mcp + pptx-mcp (document editing)
+#   word    — word-mcp only (Word document editing)
+#   pptx    — pptx-mcp only (PowerPoint editing)
 #   image   — imagegen-mcp (image generation)
 #   all     — everything enabled (may degrade with smaller models)
 set -euo pipefail
@@ -15,35 +16,64 @@ write_crush_config() {
     local word_disabled="$1"
     local pptx_disabled="$2"
     local imagegen_disabled="$3"
+    local system_prompt="${4:-}"
+    local model_override="${5:-}"
+
+    local providers_block=""
+    local models_block=""
+    if [[ -n "$system_prompt" ]]; then
+        providers_block=",
+  \"providers\": {
+    \"ollama\": {
+      \"system_prompt_prefix\": $(printf '%s' "$system_prompt" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')
+    }
+  }"
+    fi
+    if [[ -n "$model_override" ]]; then
+        models_block=",
+  \"models\": {
+    \"large\": {
+      \"model\": \"${model_override}\",
+      \"provider\": \"ollama\",
+      \"max_tokens\": 8000
+    }
+  }"
+    fi
+
     cat > .crush.json <<EOF
 {
   "mcp": {
     "word-mcp": { "disabled": ${word_disabled} },
     "pptx-mcp": { "disabled": ${pptx_disabled} },
     "imagegen-mcp": { "disabled": ${imagegen_disabled} }
-  }
+  }${providers_block}${models_block}
 }
 EOF
 }
 
 task="${1:-}"
+DEFAULT_MODEL="gemma4-65k"
 
 if [[ -z "$task" ]]; then
     echo
     echo "  --- Crush Task Profiles ---"
     echo "  [1] Coding          (no MCP - fast, all context for code)"
-    echo "  [2] Office docs     (Word + PowerPoint MCP)"
-    echo "  [3] Image gen       (FLUX.1-schnell MCP)"
-    echo "  [4] All tools       (all MCP servers - may be slow)"
+    echo "  [2] Word docs       (Word MCP only - 54 tools)"
+    echo "  [3] PowerPoint      (PPTX MCP only - 37 tools)"
+    echo "  [4] Document create (guided co-authoring workflow)"
+    echo "  [5] Image gen       (FLUX.1-schnell MCP)"
+    echo "  [6] All tools       (all MCP servers - may be slow)"
     echo
     read -rp "  Select profile [1]: " choice
     choice="${choice:-1}"
 
     case "$choice" in
         1) task="coding" ;;
-        2) task="office" ;;
-        3) task="image" ;;
-        4) task="all" ;;
+        2) task="word" ;;
+        3) task="pptx" ;;
+        4) task="docs" ;;
+        5) task="image" ;;
+        6) task="all" ;;
         *)
             echo "  Invalid selection, defaulting to coding."
             task="coding"
@@ -51,26 +81,97 @@ if [[ -z "$task" ]]; then
     esac
 fi
 
+PPTX_GUIDE="IMPORTANT: Be concise. Do not explain what you will do — just do it. Minimize output.
+
+ppt-mcp controls a live PowerPoint instance via COM automation (154 tools).
+
+WORKFLOW: Open file in PowerPoint → ppt_activate_presentation → edit → ppt_save_presentation
+
+ESSENTIAL TOOLS:
+- ppt_activate_presentation (CALL FIRST after opening a file!)
+- ppt_find_replace_text, ppt_set_text, ppt_get_text, ppt_get_all_text
+- ppt_get_slide_info, ppt_list_slides, ppt_add_slide, ppt_delete_slide
+- ppt_save_presentation, ppt_save_presentation_as (export to PDF/PNG)
+
+ADVANCED TOOLS (use these for professional results):
+- Charts: ppt_add_chart (20+ types: column, bar, line, pie, scatter, area, doughnut, radar)
+  → ppt_set_chart_data → ppt_format_chart
+- SmartArt: ppt_add_smartart (any layout: Process, Org Chart, Cycle, Funnel, Venn, Timeline)
+  → ppt_modify_smartart (set_text, add_node, change_layout, change_color)
+- Tables: ppt_add_table → ppt_set_table_data (batch write) → ppt_merge_table_cells
+  → ppt_set_table_borders → ppt_set_table_style
+- Themes: ppt_set_theme_colors (17 presets: corporate_blue, executive, nord_light, etc.
+  OR auto-generate harmonious palette from one brand color)
+- Animations: ppt_add_animation (entrance/exit/emphasis/motion path, 50+ effects)
+  → ppt_set_slide_transition (fade, push, wipe, dissolve)
+- Layout: ppt_align_shapes, ppt_distribute_shapes, ppt_merge_shapes (boolean ops)
+- Icons: ppt_add_svg_icon (2500+ Material Symbols) → ppt_search_icons to find by keyword
+- Typography: ppt_check_typography (auto-fix widow lines, shrunk text)
+
+DESIGN PRINCIPLES:
+- Set a bold color palette FIRST with ppt_set_theme_colors (don't default to blue)
+- Every slide needs a visual element: image, chart, icon, SmartArt, or shape
+- Don't repeat the same layout on consecutive slides
+- Typography: Title 36-44pt bold, Body 14-16pt, Captions 10-12pt
+- Use two-column, icon+text, grid, or half-bleed image layouts for variety
+
+QA: After editing, use ppt_get_slide_preview on modified slides to verify visually.
+Check for: overlapping elements, text overflow, low-contrast text, misaligned columns."
+
+WORD_GUIDE="docx-mcp-server Tool Guide:
+This server edits Word documents via direct OOXML manipulation. Key tools:
+- Open/create documents, then edit with tracked changes visible in Word
+- search_and_replace: Find and replace text
+- add_paragraph / add_heading / add_table: Add content
+- format_text: Apply formatting
+- Supports footnotes, endnotes, comments, headers/footers, sections
+- All edits create real tracked changes (visible in Word's Review tab)"
+
 case "$task" in
     coding)
-        write_crush_config true true true
+        write_crush_config true true true "" "$DEFAULT_MODEL"
         echo "  Profile: Coding (no MCP servers)"
         ;;
-    office)
-        write_crush_config false false true
-        echo "  Profile: Office (Word + PowerPoint)"
+    word)
+        write_crush_config false true true "$WORD_GUIDE" "$DEFAULT_MODEL"
+        echo "  Profile: Word (docx-mcp-server, 45 tools)"
+        ;;
+    pptx)
+        export CRUSH_SHORT_TOOL_DESCRIPTIONS=1
+        write_crush_config true false true "$PPTX_GUIDE" "$DEFAULT_MODEL"
+        echo "  Profile: PowerPoint (ppt-mcp COM, 154 tools, short descriptions)"
+        ;;
+    docs)
+        # Download latest doc-coauthoring skill in background
+        DOC_SKILL_DIR="${HOME}/.config/crush/skills/doc-coauthoring"
+        DOC_SKILL_FILE="${DOC_SKILL_DIR}/SKILL.md"
+        (
+            mkdir -p "$DOC_SKILL_DIR"
+            curl -fsSL --max-time 5 \
+                "https://raw.githubusercontent.com/anthropics/skills/main/skills/doc-coauthoring/SKILL.md" \
+                -o "$DOC_SKILL_FILE" 2>/dev/null
+        ) &
+
+        # Load skill content into system prompt if available
+        DOCS_GUIDE="You are a document co-authoring assistant. Guide the user through structured document creation."
+        if [[ -f "$DOC_SKILL_FILE" ]]; then
+            DOCS_GUIDE="$(cat "$DOC_SKILL_FILE")"
+        fi
+        write_crush_config false true true "$DOCS_GUIDE" "$DEFAULT_MODEL"
+        echo "  Profile: Document creation (doc-coauthoring skill + Word MCP)"
         ;;
     image)
-        write_crush_config true true false
-        echo "  Profile: Image generation (FLUX.1-schnell)"
+        write_crush_config true true false "" "qwen3:14b"
+        echo "  Profile: Image generation (FLUX.1-schnell) — using qwen3:14b for VRAM headroom"
         ;;
     all)
-        write_crush_config false false false
+        export CRUSH_SHORT_TOOL_DESCRIPTIONS=1
+        write_crush_config false false false "" "$DEFAULT_MODEL"
         echo "  Profile: All tools (93 MCP tools - may be slow with smaller models)"
         ;;
     *)
         echo "  Unknown profile '$task', defaulting to coding."
-        write_crush_config true true true
+        write_crush_config true true true "" "$DEFAULT_MODEL"
         echo "  Profile: Coding (no MCP servers)"
         ;;
 esac

--- a/local-llm/scripts/imagegen-launch.ps1
+++ b/local-llm/scripts/imagegen-launch.ps1
@@ -1,6 +1,6 @@
 # imagegen-launch.ps1 — Start imagegen server, wait for ready, launch Copilot, cleanup on exit
 param(
-    [string]$Model = "glm-4.7-flash",
+    [string]$Model = "gemma4-65k",
     [int]$Port = 8001,
     [string]$Quality = "fast"
 )

--- a/local-llm/windows/install-windows.ps1
+++ b/local-llm/windows/install-windows.ps1
@@ -22,9 +22,8 @@
 
 .PARAMETER ModelProfile
     GPU/environment profile that determines which models to pull:
-      Desktop — RTX 5090 (32GB). Pulls glm-4.7-flash, qwen3:14b, deepseek-r1:32b (~46 GB).
-      Server  — RTX 4090 (24GB dedicated). Pulls glm-4.7-flash, qwen2.5-coder:14b,
-               deepseek-r1:32b (~45 GB).
+      Desktop — RTX 5090 (32GB). Pulls gemma4:26b, qwen3:14b (~26 GB).
+      Server  — RTX 4090 (24GB dedicated). Pulls gemma4:26b, qwen3:14b (~26 GB).
     Ignored in Client mode.
 
 .PARAMETER OllamaHost
@@ -111,15 +110,13 @@ if ($Help) {
     -Mode Client    Install client tools only (Crush, Copilot CLI, uv, MCP). Requires -OllamaHost.
 
   GPU PROFILES:
-    -ModelProfile Desktop   RTX 5090 (32GB) — 3 task-optimized models, ~46 GB total:
-                              glm-4.7-flash       Heavy coding / docs / creative / office (202k ctx)
-                              qwen3:14b           Light coding
-                              deepseek-r1:32b     Code review / reasoning
+    -ModelProfile Desktop   RTX 5090 (32GB) — 2 models, ~26 GB total:
+                              gemma4-65k          General (256k ctx)
+                              qwen3:14b           Image gen profile (VRAM-friendly)
 
-    -ModelProfile Server    RTX 4090 (24GB dedicated) — 3 models, ~45 GB total:
-                              glm-4.7-flash        Heavy coding / docs / creative / office (202k ctx)
-                              qwen2.5-coder:14b    Light coding
-                              deepseek-r1:32b      Code review / reasoning
+    -ModelProfile Server    RTX 4090 (24GB dedicated) — 2 models, ~26 GB total:
+                              gemma4-65k           General (256k ctx)
+                              qwen3:14b            Image gen profile (VRAM-friendly)
 
   OPTIONS:
     -OllamaHost <url>    Remote Ollama endpoint (required for Client mode)
@@ -175,29 +172,25 @@ $script:Warnings = @()
 
 # Known model descriptions for progress display
 $KnownModelDescriptions = @{
-    "glm-4.7-flash"                  = "GLM-4.7-Flash 30B MoE — heavy coding/docs/creative/office (202k ctx), ~17 GB"
-    "qwen2.5-coder:14b"              = "Qwen2.5-Coder 14B — light coding, ~9 GB"
-    "deepseek-r1:32b"                = "DeepSeek R1 32B — code review/reasoning, ~19 GB"
-    "qwen3:14b"                      = "Qwen3 14B — light coding (40k ctx), ~9 GB"
+    "gemma4:26b"                     = "Gemma 4 26B MoE — general (256k ctx), ~17 GB"
+    "qwen3:14b"                      = "Qwen3 14B — image gen profile, VRAM-friendly (131k ctx), ~9 GB"
 }
 
 $ProfileDefinitions = @{
     "Desktop" = @{
         Description = "RTX 5090 (32GB) — gaming desktop with IDEs open (~25-27 GB available)"
-        RequiredGB = 46
+        RequiredGB = 26
         Models = [ordered]@{
-            "glm-4.7-flash"              = $KnownModelDescriptions["glm-4.7-flash"]
+            "gemma4:26b"                     = $KnownModelDescriptions["gemma4:26b"]
             "qwen3:14b"                  = $KnownModelDescriptions["qwen3:14b"]
-            "deepseek-r1:32b"            = $KnownModelDescriptions["deepseek-r1:32b"]
         }
     }
     "Server" = @{
-        Description = "RTX 4090 (24GB) — dedicated server, full VRAM (containers use 0 GPU)"
-        RequiredGB = 45
+        Description = "RTX 4090 (24GB) — dedicated server, full VRAM"
+        RequiredGB = 26
         Models = [ordered]@{
-            "glm-4.7-flash"        = $KnownModelDescriptions["glm-4.7-flash"]
-            "qwen2.5-coder:14b"    = $KnownModelDescriptions["qwen2.5-coder:14b"]
-            "deepseek-r1:32b"      = $KnownModelDescriptions["deepseek-r1:32b"]
+            "gemma4:26b"             = $KnownModelDescriptions["gemma4:26b"]
+            "qwen3:14b"            = $KnownModelDescriptions["qwen3:14b"]
         }
     }
 }
@@ -549,6 +542,9 @@ if ($ShouldInstallSoftware) {
         }
 
         Set-UserEnvironmentVariable -Name "OLLAMA_KEEP_ALIVE" -Value "5m"
+        Set-UserEnvironmentVariable -Name "OLLAMA_FLASH_ATTENTION" -Value "1"
+        Set-UserEnvironmentVariable -Name "OLLAMA_KV_CACHE_TYPE" -Value "q8_0"
+        Write-Info "OLLAMA_FLASH_ATTENTION=1 and OLLAMA_KV_CACHE_TYPE=q8_0 reduce VRAM usage for large contexts."
 
         if (-not [string]::IsNullOrWhiteSpace($ModelPath)) {
             if (-not (Test-Path $ModelPath)) {
@@ -594,22 +590,29 @@ if ($ShouldInstallSoftware) {
         Write-Info "Launch Crush after install and set its provider endpoint to $OllamaHost."
     }
 
-    # ── Step: MCP server directory ───────────────────────────────────────
+    # ── Step: Install MCP tools ──────────────────────────────────────────
 
-    Write-Step "Create MCP server directories"
-    Write-Info "MCP servers will live in isolated uv venvs under $AiToolsDir."
+    Write-Step "Install MCP tools (uv global)"
+    Write-Info "MCP servers installed as uv tools — accessible via 'uvx' command."
 
-    $mcpDirs = @(
-        (Join-Path $AiToolsDir "mcp-word")
-        (Join-Path $AiToolsDir "mcp-pptx")
+    $mcpTools = @(
+        @{ Package = "ppt-mcp";         Python = $null;  Desc = "PowerPoint COM automation" }
+        @{ Package = "docx-mcp-server"; Python = "3.12"; Desc = "Word OOXML editing" }
     )
 
-    foreach ($dir in $mcpDirs) {
-        if (-not (Test-Path $dir)) {
-            New-Item -ItemType Directory -Path $dir -Force | Out-Null
-            Write-Success "Created $dir"
+    foreach ($tool in $mcpTools) {
+        Write-Host "  Installing $($tool.Desc)..." -ForegroundColor White
+        $uvArgs = @("tool", "install", $tool.Package)
+        if ($tool.Python) {
+            $uvArgs += "--python"
+            $uvArgs += $tool.Python
+        }
+        uv @uvArgs 2>&1 | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Success "$($tool.Package) ready."
         } else {
-            Write-Info "$dir already exists."
+            Write-Warn "$($tool.Package) install failed."
+            $script:Failures += "MCP: $($tool.Package)"
         }
     }
 
@@ -643,6 +646,39 @@ if ($ShouldInstallSoftware) {
         }
     } else {
         Write-Warn "Config template not found at $crushConfigSource — skipping Crush config."
+    }
+
+    # ── Step: Deploy Crush skills and MCP servers ───────────────────────
+
+    Write-Step "Deploy Crush skills and MCP servers"
+
+    # Deploy plan-mode MCP server
+    $mcpSourceDir = Join-Path $PSScriptRoot "..\config\mcp"
+    $mcpDestDir = Join-Path $CrushDir "mcp"
+    if (Test-Path $mcpSourceDir) {
+        New-Item -ItemType Directory -Path $mcpDestDir -Force | Out-Null
+        Copy-Item "$mcpSourceDir\*" $mcpDestDir -Recurse -Force
+        Write-Success "Deployed MCP servers to $mcpDestDir"
+    }
+
+    # Deploy local skills from dotFiles
+    $skillsSourceDir = Join-Path $PSScriptRoot "..\config\skills"
+    $skillsDestDir = Join-Path $CrushDir "skills"
+    if (Test-Path $skillsSourceDir) {
+        New-Item -ItemType Directory -Path $skillsDestDir -Force | Out-Null
+        Copy-Item "$skillsSourceDir\*" $skillsDestDir -Recurse -Force
+        Write-Success "Deployed local skills (plan-mode, git-safety) to $skillsDestDir"
+    }
+
+    # Download latest doc-coauthoring skill from anthropics/skills
+    $docCoauthoringDir = Join-Path $skillsDestDir "doc-coauthoring"
+    New-Item -ItemType Directory -Path $docCoauthoringDir -Force | Out-Null
+    $docCoauthoringUrl = "https://raw.githubusercontent.com/anthropics/skills/main/skills/doc-coauthoring/SKILL.md"
+    try {
+        Invoke-WebRequest -Uri $docCoauthoringUrl -OutFile (Join-Path $docCoauthoringDir "SKILL.md") -ErrorAction Stop
+        Write-Success "Downloaded latest doc-coauthoring skill from anthropics/skills"
+    } catch {
+        Write-Warn "Could not download doc-coauthoring skill: $_"
     }
 
     # ── Step: Deploy Copilot CLI MCP configuration ────────────────────
@@ -795,6 +831,27 @@ if ($ShouldPullModels) {
                     $script:Failures += "Model: $tag"
                 }
                 Write-Host ""
+            }
+
+            # Set num_ctx on models via Modelfiles (Ollama defaults to 2048)
+            Write-Host "  Setting context window (num_ctx) on models..." -ForegroundColor White
+            $numCtxSettings = @{
+                "gemma4:26b"    = 65536
+                "qwen3:14b"     = 16384
+            }
+            foreach ($entry in $numCtxSettings.GetEnumerator()) {
+                $tag = $entry.Key
+                $ctx = $entry.Value
+                $modelfilePath = Join-Path $env:TEMP "Modelfile-$($tag -replace '[:\.]', '-')"
+                @"
+FROM $tag
+PARAMETER num_ctx $ctx
+"@ | Set-Content $modelfilePath
+                ollama create $tag -f $modelfilePath 2>$null
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Info "  $tag → num_ctx $ctx"
+                }
+                Remove-Item $modelfilePath -ErrorAction SilentlyContinue
             }
         }
     }

--- a/local-llm/windows/remove-windows.ps1
+++ b/local-llm/windows/remove-windows.ps1
@@ -305,7 +305,7 @@ Write-Info "No manual PATH cleanup required."
 if ($IsFullMode) {
     Write-Step "Remove Ollama environment variables"
 
-    $envVarsToRemove = @("OLLAMA_HOST", "OLLAMA_KEEP_ALIVE", "OLLAMA_MODELS")
+    $envVarsToRemove = @("OLLAMA_HOST", "OLLAMA_KEEP_ALIVE", "OLLAMA_MODELS", "OLLAMA_FLASH_ATTENTION", "OLLAMA_KV_CACHE_TYPE")
     foreach ($varName in $envVarsToRemove) {
         $current = [Environment]::GetEnvironmentVariable($varName, "User")
         if ($null -ne $current) {


### PR DESCRIPTION
Model changes:
- Replace GLM-4.7-Flash, Qwen2.5-Coder, DeepSeek-R1 with Gemma 4 26B as the single general-purpose model for all task profiles (coding, docs, creative, office)
- Retain Qwen3 14B only for image generation (VRAM headroom for FLUX.1)
- Switch CachyOS server from vLLM multi-model to Ollama with matching Gemma 4 + Qwen3 model set
- Add Groq and OpenRouter as cloud fallback providers

Extensibility (Crush):
- Add plan-mode MCP server (plan_mode_server.py) with enable/disable/status tools and PreToolUse hook to block write tools when plan mode is active
- Add git-safety PreToolUse hook blocking git write operations (commit, push, merge, rebase, etc.) via exit-code-2 enforcement
- Add plan-mode and git-safety SKILL.md files for agent behavior guidance
- Add doc-coauthoring profile that downloads the latest skill from anthropics/skills at launch time (background, non-blocking)
- Expand PPTX system prompt from ~100 to ~600 tokens with advanced tool awareness (charts, SmartArt, tables, themes, animations, icons, layout, typography, QA workflow, design principles)
- Create shared pptx-instructions.md for Copilot CLI custom instructions

Extensibility (Copilot CLI):
- Add --deny-tool flags for git write operations in copilot-local.cmd/.sh
- Wire PPTX custom instructions for Office document profiles
- Add planmode MCP server to copilot-mcp-config.json

Task profiles:
- Add 'Document create' profile ([4]) to crush-task.ps1/.sh with guided co-authoring workflow, auto-downloading skill, and Word MCP
- Renumber Image gen to [5], All tools to [6]

Installers:
- Deploy MCP servers, skills, and crush config hooks during installation
- Download doc-coauthoring SKILL.md from GitHub at install time (not bundled)
- Add 5090 model evaluation plan as standalone prompt document