### PR TITLE
 crush: update and add General/Guided profiles

### DIFF
--- a/local-llm/config/crush.json
+++ b/local-llm/config/crush.json
@@ -208,19 +208,13 @@
     "PreToolUse": [
       {
         "matcher": "bash|edit|write|notebook_edit|mcp__filesystem",
-        "hook": {
-          "type": "command",
-          "command": "python__EXE_SUFFIX__ -c \"import sys; from pathlib import Path; f=Path.home()/'.config'/'crush'/'plan-mode'; sys.exit(2) if f.exists() else sys.exit(0)\"",
-          "timeout_secs": 5
-        }
+        "command": "python__EXE_SUFFIX__ -c \"import sys; from pathlib import Path; f=Path.home()/'.config'/'crush'/'plan-mode'; sys.exit(2) if f.exists() else sys.exit(0)\"",
+        "timeout": 5
       },
       {
         "matcher": "mcp__git__(add|commit|push|merge|rebase|reset|stash|checkout_branch|delete_branch|tag|cherry_pick|revert)",
-        "hook": {
-          "type": "command",
-          "command": "python__EXE_SUFFIX__ -c \"import sys; print('Git write operations are blocked by policy.'); sys.exit(2)\"",
-          "timeout_secs": 5
-        }
+        "command": "python__EXE_SUFFIX__ -c \"import sys; print('Git write operations are blocked by policy.'); sys.exit(2)\"",
+        "timeout": 5
       }
     ]
   }

--- a/local-llm/scripts/crush-task.ps1
+++ b/local-llm/scripts/crush-task.ps1
@@ -8,9 +8,12 @@
     keeping the tool count low so the model can reliably use them all.
 
     Profiles:
+      General     — Word MCP + gh CLI (default — research & document authoring)
       Coding      — no MCP servers (code tools only)
+      Code review — Qwen2.5-Coder model, no MCP (different perspective)
       Word        — word-mcp only (Word document editing)
       PowerPoint  — pptx-mcp only (PowerPoint editing)
+      Guided auth — doc-coauthoring skill + Word MCP (structured workflow)
       Image       — imagegen-mcp (image generation)
       All         — everything enabled (may degrade with smaller models)
 
@@ -19,7 +22,7 @@
 #>
 
 param(
-    [ValidateSet("coding", "review", "word", "pptx", "docs", "image", "all")]
+    [ValidateSet("general", "coding", "review", "word", "pptx", "docs", "image", "all")]
     [string]$Task
 )
 
@@ -57,28 +60,30 @@ function Write-CrushConfig {
 if (-not $Task) {
     Write-Host ""
     Write-Host "  --- Crush Task Profiles ---"
-    Write-Host "  [1] Coding          (no MCP - fast, all context for code)"
-    Write-Host "  [2] Code review     (Qwen2.5-Coder - different perspective)"
-    Write-Host "  [3] Word docs       (Word MCP only - 54 tools)"
-    Write-Host "  [4] PowerPoint      (PPTX MCP only - 37 tools)"
-    Write-Host "  [5] Document create (guided co-authoring workflow)"
-    Write-Host "  [6] Image gen       (FLUX.1-schnell MCP)"
-    Write-Host "  [7] All tools       (all MCP servers - may be slow)"
+    Write-Host "  [1] General           (general research and document authoring)"
+    Write-Host "  [2] Coding            (no MCP - fast, all context for code)"
+    Write-Host "  [3] Code review       (Qwen2.5-Coder - different perspective)"
+    Write-Host "  [4] Word docs         (Word MCP only - focused editing)"
+    Write-Host "  [5] PowerPoint        (PPTX MCP only)"
+    Write-Host "  [6] Guided authoring  (guided document authoring workflow)"
+    Write-Host "  [7] Image gen         (FLUX.1-schnell MCP)"
+    Write-Host "  [8] All tools         (all MCP servers - may be slow)"
     Write-Host ""
     $choice = Read-Host "  Select profile [1]"
     if (-not $choice) { $choice = "1" }
 
     switch ($choice) {
-        "1" { $Task = "coding" }
-        "2" { $Task = "review" }
-        "3" { $Task = "word" }
-        "4" { $Task = "pptx" }
-        "5" { $Task = "docs" }
-        "6" { $Task = "image" }
-        "7" { $Task = "all" }
+        "1" { $Task = "general" }
+        "2" { $Task = "coding" }
+        "3" { $Task = "review" }
+        "4" { $Task = "word" }
+        "5" { $Task = "pptx" }
+        "6" { $Task = "docs" }
+        "7" { $Task = "image" }
+        "8" { $Task = "all" }
         default {
-            Write-Host "  Invalid selection, defaulting to coding."
-            $Task = "coding"
+            Write-Host "  Invalid selection, defaulting to general."
+            $Task = "general"
         }
     }
 }
@@ -91,6 +96,14 @@ switch ($Task) {
             "imagegen-mcp" = @{ disabled = $true }
         } -Model $DefaultModel
         Write-Host "  Profile: Coding (no MCP servers)"
+    }
+    "general" {
+        Write-CrushConfig -McpOverrides @{
+            "word-mcp"     = @{ disabled = $false }
+            "pptx-mcp"     = @{ disabled = $true }
+            "imagegen-mcp" = @{ disabled = $true }
+        } -Model $DefaultModel
+        Write-Host "  Profile: General (Word MCP + gh CLI)"
     }
     "review" {
         $reviewGuide = @"
@@ -129,7 +142,6 @@ This server edits Word documents via direct OOXML manipulation. Key tools:
         Write-Host "  Profile: Word (docx-mcp-server, 45 tools)"
     }
     "pptx" {
-        $env:CRUSH_SHORT_TOOL_DESCRIPTIONS = "1"
         $pptxGuide = @"
 IMPORTANT: Be concise. Do not explain what you will do — just do it. Minimize output.
 
@@ -208,7 +220,7 @@ Check for: overlapping elements, text overflow, low-contrast text, misaligned co
             "pptx-mcp"     = @{ disabled = $true }
             "imagegen-mcp" = @{ disabled = $true }
         } -SystemPromptPrefix $docsGuide -Model $DefaultModel
-        Write-Host "  Profile: Document creation (doc-coauthoring skill + Word MCP)"
+        Write-Host "  Profile: Guided document authoring (doc-coauthoring skill + Word MCP)"
     }
     "image" {
         Write-CrushConfig -McpOverrides @{
@@ -219,7 +231,6 @@ Check for: overlapping elements, text overflow, low-contrast text, misaligned co
         Write-Host "  Profile: Image generation (FLUX.1-schnell) — using qwen3:14b for VRAM headroom"
     }
     "all" {
-        $env:CRUSH_SHORT_TOOL_DESCRIPTIONS = "1"
         Write-CrushConfig -McpOverrides @{
             "word-mcp"     = @{ disabled = $false }
             "pptx-mcp"     = @{ disabled = $false }

--- a/local-llm/scripts/crush-task.sh
+++ b/local-llm/scripts/crush-task.sh
@@ -5,9 +5,12 @@
 # for the selected task, then launches Crush.
 #
 # Profiles:
+#   general — Word MCP + gh CLI (default — research & document authoring)
 #   coding  — no MCP servers (code tools only)
+#   review  — Qwen2.5-Coder model, no MCP (different perspective)
 #   word    — word-mcp only (Word document editing)
 #   pptx    — pptx-mcp only (PowerPoint editing)
+#   docs    — doc-coauthoring skill + Word MCP (structured workflow)
 #   image   — imagegen-mcp (image generation)
 #   all     — everything enabled (may degrade with smaller models)
 set -euo pipefail
@@ -59,28 +62,30 @@ REVIEW_MODEL="qwen25coder-65k"
 if [[ -z "$task" ]]; then
     echo
     echo "  --- Crush Task Profiles ---"
-    echo "  [1] Coding          (no MCP - fast, all context for code)"
-    echo "  [2] Code review     (Qwen2.5-Coder - different perspective)"
-    echo "  [3] Word docs       (Word MCP only - 54 tools)"
-    echo "  [4] PowerPoint      (PPTX MCP only - 37 tools)"
-    echo "  [5] Document create (guided co-authoring workflow)"
-    echo "  [6] Image gen       (FLUX.1-schnell MCP)"
-    echo "  [7] All tools       (all MCP servers - may be slow)"
+    echo "  [1] General           (general research and document authoring)"
+    echo "  [2] Coding            (no MCP - fast, all context for code)"
+    echo "  [3] Code review       (Qwen2.5-Coder - different perspective)"
+    echo "  [4] Word docs         (Word MCP only - focused editing)"
+    echo "  [5] PowerPoint        (PPTX MCP only)"
+    echo "  [6] Guided authoring  (guided document authoring workflow)"
+    echo "  [7] Image gen         (FLUX.1-schnell MCP)"
+    echo "  [8] All tools         (all MCP servers - may be slow)"
     echo
     read -rp "  Select profile [1]: " choice
     choice="${choice:-1}"
 
     case "$choice" in
-        1) task="coding" ;;
-        2) task="review" ;;
-        3) task="word" ;;
-        4) task="pptx" ;;
-        5) task="docs" ;;
-        6) task="image" ;;
-        7) task="all" ;;
+        1) task="general" ;;
+        2) task="coding" ;;
+        3) task="review" ;;
+        4) task="word" ;;
+        5) task="pptx" ;;
+        6) task="docs" ;;
+        7) task="image" ;;
+        8) task="all" ;;
         *)
-            echo "  Invalid selection, defaulting to coding."
-            task="coding"
+            echo "  Invalid selection, defaulting to general."
+            task="general"
             ;;
     esac
 fi
@@ -120,6 +125,10 @@ case "$task" in
         write_crush_config true true true "" "$DEFAULT_MODEL"
         echo "  Profile: Coding (no MCP servers)"
         ;;
+    general)
+        write_crush_config false true true "" "$DEFAULT_MODEL"
+        echo "  Profile: General (Word MCP + gh CLI)"
+        ;;
     review)
         REVIEW_GUIDE="You are a code reviewer. Focus on:
 - Bugs, logic errors, and edge cases
@@ -137,7 +146,6 @@ Be direct. If the code is correct, say so briefly."
         echo "  Profile: Word (docx-mcp-server, 45 tools)"
         ;;
     pptx)
-        export CRUSH_SHORT_TOOL_DESCRIPTIONS=1
         write_crush_config true false true "$PPTX_GUIDE" "$DEFAULT_MODEL"
         echo "  Profile: PowerPoint (office-powerpoint-mcp-server, 32 tools)"
         ;;
@@ -164,21 +172,20 @@ Be direct. If the code is correct, say so briefly."
             fi
         fi
         write_crush_config false true true "$DOCS_GUIDE" "$DEFAULT_MODEL"
-        echo "  Profile: Document creation (doc-coauthoring skill + Word MCP)"
+        echo "  Profile: Guided document authoring (doc-coauthoring skill + Word MCP)"
         ;;
     image)
         write_crush_config true true false "" "qwen3:14b"
         echo "  Profile: Image generation (FLUX.1-schnell) — using qwen3:14b for VRAM headroom"
         ;;
     all)
-        export CRUSH_SHORT_TOOL_DESCRIPTIONS=1
         write_crush_config false false false "" "$DEFAULT_MODEL"
         echo "  Profile: All tools (93 MCP tools - may be slow with smaller models)"
         ;;
     *)
-        echo "  Unknown profile '$task', defaulting to coding."
-        write_crush_config true true true "" "$DEFAULT_MODEL"
-        echo "  Profile: Coding (no MCP servers)"
+        echo "  Unknown profile '$task', defaulting to general."
+        write_crush_config false true true "" "$DEFAULT_MODEL"
+        echo "  Profile: General (Word MCP + gh CLI)"
         ;;
 esac
 


### PR DESCRIPTION
 - Flatten hook schema in crush.json (nested "hook" wrapper → flat "command" + "timeout") to match Crush v0.68+ format
 - Remove CRUSH_SHORT_TOOL_DESCRIPTIONS env var from pptx and all profiles in both launchers (always-on since v0.68, env var is no-op)
 - Add "General" profile as default [1] with Word MCP + gh CLI
 - Add "Guided authoring" profile [6] with doc-coauthoring skill
 - Reorder menu: General, Coding, Review, Word, PPTX, Guided, Image, All
 - Fix PS1 ValidateSet to include "general"
 - Fix bash default-case fallback to "general" instead of "coding"
 - Update comment headers in both scripts to list all 8 profile