### PR TITLE
Reconcile CachyOS and Windows Ollama Installers

### DIFF
--- a/local-llm/ReadMe.md
+++ b/local-llm/ReadMe.md
@@ -36,7 +36,7 @@ cd local-llm/cachyos
 
 | Guide | For |
 |-------|-----|
-| **[windows/ReadMe.md](windows/ReadMe.md)** | Desktop setup — Ollama, 5090/4090 profiles, single-user |
+| **[windows/ReadMe.md](windows/ReadMe.md)** | Desktop setup — Ollama, 5090 profile, single-user |
 | **[cachyos/ReadMe.md](cachyos/ReadMe.md)** | Server setup — vLLM, multi-user, always-on LAN endpoint |
 
 ## Components

--- a/local-llm/cachyos/ReadMe.md
+++ b/local-llm/cachyos/ReadMe.md
@@ -73,7 +73,8 @@ The `--install` value makes the **inference engine explicit**:
 | `--install server` | vLLM server (Ollama-free) — the standing role for this box |
 | `--install local` | Local Ollama server + client tools |
 | `--install client` | Client only (Crush + MCP, no local inference) |
-| `--ollama-models 4090\|5090` | Ollama roster GPU tier (`--install local` only): 4090 (24GB) or 5090 (32GB) |
+| `--ollama-models 4090\|5090` | Ollama roster GPU tier: 4090 (24GB) or 5090 (32GB). Applies to `--install local`, and to `--install client` when `--providers` includes `local` |
+| `--test-profiles` | Also install the experimental/bench models (North Mini Code, Nemotron Cascade 2, Ornith-1.0-35B, Qwen3-Next-80B); default is the 6 production models only |
 | `--no-client-tools` | With `--install local`: install the Ollama server + models only (no Crush/MCP) |
 | `--providers local,server` | Crush providers to enable (`server` = the vLLM provider) |
 | `--skip-models` | Install software only |
@@ -82,8 +83,8 @@ The `--install` value makes the **inference engine explicit**:
 | `--model-path /path` | Custom HuggingFace cache location |
 | `--ollama-host URL` | Remote endpoint (client mode) |
 
-> Legacy `--mode`/`--model-profile` and the `squire-server` provider name are still accepted as
-> deprecated aliases (`--mode server` → `--install server`, `--model-profile server` → `--ollama-models 4090`).
+> Legacy `--mode` and the `squire-server` provider name remain accepted as deprecated
+> aliases (e.g. `--mode server` → `--install server`; `--providers squire-server` → `--providers server`).
 
 ## Configure
 

--- a/local-llm/cachyos/install-cachyos.sh
+++ b/local-llm/cachyos/install-cachyos.sh
@@ -17,7 +17,8 @@ NO_CLIENT_TOOLS=false
 # Ollama model roster GPU tier (local/Ollama installs only): 4090 (24GB) | 5090 (32GB).
 # Default 4090 — the CachyOS box is the 4090. Selected via --ollama-models.
 OLLAMA_TIER="4090"
-MODEL_PROFILE=""   # deprecated alias for --ollama-models (desktop->5090, server->4090)
+OLLAMA_TIER_EXPLICIT=false   # true once --ollama-models is passed (for the "no local provider" warning)
+TEST_PROFILES=false          # --test-profiles: also install the experimental/bench models (mirrors Windows)
 OLLAMA_HOST_ARG=""
 MODEL_PATH=""
 SKIP_MODELS=false
@@ -90,9 +91,12 @@ Options:
                                ('squire-server' is accepted as a legacy alias for 'server'.)
   --default-provider <p>       Default crush provider: local | server
                                (default: local->local; server/client->server)
-  --ollama-models 4090|5090    Ollama roster GPU tier (local installs only): 4090 (24GB) or 5090 (32GB).
-                               Default: 4090. Distinct per-tier aliases + tier-safe contexts.
-                               (Deprecated: --model-profile desktop|server, mapped desktop->5090, server->4090.)
+  --ollama-models 4090|5090    Ollama roster GPU tier: 4090 (24GB) or 5090 (32GB). Default: 4090.
+                               Distinct per-tier aliases + tier-safe contexts. Applies to local installs
+                               AND to client installs whose --providers includes 'local' (it selects the
+                               launcher's model-alias menu so it matches the remote Ollama server's tier).
+  --test-profiles              Also install the experimental/bench models (North Mini Code, Nemotron
+                               Cascade 2, Ornith-1.0-35B, Qwen3-Next-80B). Default: production roster only.
   --squire-server-ip <ip>      Remote (server) address for client/local installs (default: 192.168.1.99)
   --squire-ssh-target <target> SSH target for the server model-switch (default: jesse@192.168.1.99)
   --ollama-host <url>          Optional extra remote Ollama provider (NOT required for client mode)
@@ -251,8 +255,11 @@ populate_ollama_tier() {
     local ornith="hf.co/deepreinforce-ai/Ornith-1.0-35B-GGUF:Q4_K_M"
     local qwen3next="hf.co/Qwen/Qwen3-Next-80B-A3B-Instruct-GGUF:Q4_K_M"
 
-    OLLAMA_PULL_TAGS=("$mtp" "$q36_35b" "$gemma4" "$coder" "$glm" "$img" \
-                      "$northmini" "$nemotron" "$ornith" "$qwen3next")
+    # Production roster (always). Experimental/bench models are added only with --test-profiles.
+    OLLAMA_PULL_TAGS=("$mtp" "$q36_35b" "$gemma4" "$coder" "$glm" "$img")
+    if [[ "$TEST_PROFILES" == true ]]; then
+        OLLAMA_PULL_TAGS+=("$northmini" "$nemotron" "$ornith" "$qwen3next")
+    fi
 
     # Per-tier alias names + contexts (24GB-safe on 4090; full on 5090).
     local a_heavy a_q3635 a_gemma a_coder a_glm a_north a_nemo a_ornith
@@ -284,21 +291,6 @@ populate_ollama_tier() {
     OLLAMA_ALIAS_FROM["$a_gemma"]="$gemma4";     OLLAMA_ALIAS_CTX["$a_gemma"]="$c_gemma"
     OLLAMA_ALIAS_FROM["$a_coder"]="$coder";      OLLAMA_ALIAS_CTX["$a_coder"]="$c_coder"
     OLLAMA_ALIAS_FROM["$a_glm"]="$glm";          OLLAMA_ALIAS_CTX["$a_glm"]="$c_glm"
-    OLLAMA_ALIAS_FROM["$a_north"]="$northmini";  OLLAMA_ALIAS_CTX["$a_north"]="$c_north"
-    OLLAMA_ALIAS_FROM["$a_nemo"]="$nemotron";    OLLAMA_ALIAS_CTX["$a_nemo"]="$c_nemo"
-    OLLAMA_ALIAS_FROM["$a_ornith"]="$ornith";    OLLAMA_ALIAS_CTX["$a_ornith"]="$c_ornith"
-    OLLAMA_ALIAS_FROM["$a_offload"]="$qwen3next"; OLLAMA_ALIAS_CTX["$a_offload"]="$c_offload"
-
-    # Qwen3-Next needs an explicit ChatML template baked in (the GGUF's embedded
-    # template renders an immediate-EOS empty reply under Ollama).
-    OLLAMA_ALIAS_TEMPLATE["$a_offload"]='{{ if .System }}<|im_start|>system
-{{ .System }}<|im_end|>
-{{ end }}{{ range .Messages }}{{ if eq .Role "user" }}<|im_start|>user
-{{ .Content }}<|im_end|>
-{{ else if eq .Role "assistant" }}<|im_start|>assistant
-{{ .Content }}<|im_end|>
-{{ end }}{{ end }}<|im_start|>assistant
-'
 
     # Task->alias SLOT map (drives the launcher tier config).
     OLLAMA_SLOT[heavy]="$a_heavy"
@@ -311,10 +303,6 @@ populate_ollama_tier() {
     OLLAMA_SLOT[h3]="$a_gemma"
     OLLAMA_SLOT[h4]="$a_coder"
     OLLAMA_SLOT[h5]="$a_glm"
-    OLLAMA_SLOT[h6]="$a_north"
-    OLLAMA_SLOT[h7]="$a_nemo"
-    OLLAMA_SLOT[h8]="$a_ornith"
-    OLLAMA_SLOT[o2]="$a_offload"
 
     # Friendly labels (identity is tier-independent).
     OLLAMA_ALIAS_LABEL["$a_heavy"]="Qwen3.6 27B (+MTP)"
@@ -322,11 +310,35 @@ populate_ollama_tier() {
     OLLAMA_ALIAS_LABEL["$a_gemma"]="Gemma 4 31B"
     OLLAMA_ALIAS_LABEL["$a_coder"]="Qwen3-Coder 30B-A3B"
     OLLAMA_ALIAS_LABEL["$a_glm"]="GLM-4.7-Flash"
-    OLLAMA_ALIAS_LABEL["$a_north"]="North Mini Code 1.0"
-    OLLAMA_ALIAS_LABEL["$a_nemo"]="Nemotron Cascade 2 30B-A3B"
-    OLLAMA_ALIAS_LABEL["$a_ornith"]="Ornith-1.0-35B"
     OLLAMA_ALIAS_LABEL["$img"]="Qwen3 8B"
-    OLLAMA_ALIAS_LABEL["$a_offload"]="Qwen3-Next-80B-A3B (partial offload)"
+
+    # Experimental/bench models — registered only with --test-profiles (aliases, bench task slots
+    # [H6]-[H8]/[O2], friendly labels, and the Qwen3-Next ChatML template). Kept out of the maps
+    # otherwise so the alias-creation loop never tries to build an un-pulled model.
+    if [[ "$TEST_PROFILES" == true ]]; then
+        OLLAMA_ALIAS_FROM["$a_north"]="$northmini";   OLLAMA_ALIAS_CTX["$a_north"]="$c_north"
+        OLLAMA_ALIAS_FROM["$a_nemo"]="$nemotron";     OLLAMA_ALIAS_CTX["$a_nemo"]="$c_nemo"
+        OLLAMA_ALIAS_FROM["$a_ornith"]="$ornith";     OLLAMA_ALIAS_CTX["$a_ornith"]="$c_ornith"
+        OLLAMA_ALIAS_FROM["$a_offload"]="$qwen3next"; OLLAMA_ALIAS_CTX["$a_offload"]="$c_offload"
+        OLLAMA_SLOT[h6]="$a_north"
+        OLLAMA_SLOT[h7]="$a_nemo"
+        OLLAMA_SLOT[h8]="$a_ornith"
+        OLLAMA_SLOT[o2]="$a_offload"
+        OLLAMA_ALIAS_LABEL["$a_north"]="North Mini Code 1.0"
+        OLLAMA_ALIAS_LABEL["$a_nemo"]="Nemotron Cascade 2 30B-A3B"
+        OLLAMA_ALIAS_LABEL["$a_ornith"]="Ornith-1.0-35B"
+        OLLAMA_ALIAS_LABEL["$a_offload"]="Qwen3-Next-80B-A3B (partial offload)"
+        # Qwen3-Next needs an explicit ChatML template baked in (the GGUF's embedded template
+        # renders an immediate-EOS empty reply under Ollama).
+        OLLAMA_ALIAS_TEMPLATE["$a_offload"]='{{ if .System }}<|im_start|>system
+{{ .System }}<|im_end|>
+{{ end }}{{ range .Messages }}{{ if eq .Role "user" }}<|im_start|>user
+{{ .Content }}<|im_end|>
+{{ else if eq .Role "assistant" }}<|im_start|>assistant
+{{ .Content }}<|im_end|>
+{{ end }}{{ end }}<|im_start|>assistant
+'
+    fi
 }
 
 # Path the launchers source for their tier-aware alias set.
@@ -653,15 +665,15 @@ parse_args() {
                 DEFAULT_PROVIDER="$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')"
                 shift 2
                 ;;
-            --model-profile)
-                [[ $# -lt 2 ]] && { fail "--model-profile requires a value."; usage; exit 1; }
-                MODEL_PROFILE="$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')"
-                shift 2
-                ;;
             --ollama-models)
                 [[ $# -lt 2 ]] && { fail "--ollama-models requires a value (4090|5090)."; usage; exit 1; }
                 OLLAMA_TIER="$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')"
+                OLLAMA_TIER_EXPLICIT=true
                 shift 2
+                ;;
+            --test-profiles)
+                TEST_PROFILES=true
+                shift
                 ;;
             --no-client-tools)
                 NO_CLIENT_TOOLS=true
@@ -766,26 +778,11 @@ case "$MODE" in
     *) fail "--mode must be client, full, or server."; exit 1 ;;
 esac
 
-# Map the deprecated --model-profile onto --ollama-models (desktop->5090, server->4090).
-if [[ -n "$MODEL_PROFILE" ]]; then
-    case "$MODEL_PROFILE" in
-        desktop) OLLAMA_TIER="5090"; info "--model-profile desktop is deprecated; use --ollama-models 5090." ;;
-        server)  OLLAMA_TIER="4090"; info "--model-profile server is deprecated; use --ollama-models 4090." ;;
-        *) fail "--model-profile must be 'desktop' or 'server' (deprecated; use --ollama-models 4090|5090)."; exit 1 ;;
-    esac
-fi
-
-# --ollama-models is valid only for local (Ollama) installs.
+# Validate the Ollama roster GPU tier.
 case "$OLLAMA_TIER" in
     4090|5090) ;;
     *) fail "--ollama-models must be 4090 or 5090."; exit 1 ;;
 esac
-if [[ "$MODE" != "full" ]]; then
-    # server/client don't run a local Ollama roster; warn if the tier was set explicitly.
-    if [[ -n "$MODEL_PROFILE" || "$OLLAMA_TIER" != "4090" ]]; then
-        add_warning "--ollama-models applies only to --install local; ignored for --install ${INSTALL}."
-    fi
-fi
 
 if [[ "$MODE" == "client" && -n "$OLLAMA_HOST_ARG" ]]; then
     info "Client mode targets the server (vLLM); --ollama-host will be kept only as an optional extra remote-Ollama provider."
@@ -870,6 +867,13 @@ for pv in ${PROVIDERS//,/ }; do
         *) fail "--providers entries must be 'local' or 'server' (got '$pv')."; exit 1 ;;
     esac
 done
+# The Ollama tier only takes effect when the launchers present local Ollama entries — i.e. when the
+# resolved providers include 'local' (true for local installs AND for client installs with a local
+# provider, where it selects the alias menu that matches the remote Ollama server's tier). Warn only if
+# a tier was set explicitly but no local provider is wired, where it has no effect.
+if [[ "$OLLAMA_TIER_EXPLICIT" == true && ",$PROVIDERS," != *",local,"* ]]; then
+    add_warning "--ollama-models ${OLLAMA_TIER} has no effect without a 'local' provider (providers=${PROVIDERS}); ignored."
+fi
 case "$DEFAULT_PROVIDER" in
     local|server) ;;
     *) fail "--default-provider must be 'local' or 'server'."; exit 1 ;;

--- a/local-llm/config/ollama-models.txt.example
+++ b/local-llm/config/ollama-models.txt.example
@@ -1,7 +1,7 @@
 # Ollama Model Pull List (OPTIONAL OVERRIDE)
 #
 # This is an EXAMPLE/template. By default the installer uses the built-in model
-# profile (-ModelProfile Desktop = the six production models, coherent with
+# roster (-OllamaModels 5090 = the six production models, coherent with
 # config\crush.json + the launcher aliases). You do NOT need this file.
 #
 # To override the profile's pull list, copy this file to `ollama-models.txt`

--- a/local-llm/windows/ReadMe.md
+++ b/local-llm/windows/ReadMe.md
@@ -15,15 +15,18 @@ Single-user AI assistant on Windows with Ollama, Crush, Copilot CLI, MCP, and lo
 | **uv** | Python toolchain (manages MCP venvs) | winget |
 | **Image Gen** | HiDream-O1-Image-Dev image generation (OpenAI API) | Python venv |
 | **copilot-local** | Task picker launcher for Copilot CLI | `~/Documents/CLI/` + PATH |
-| **MCP servers** | Office document editing (Word, PowerPoint) | Isolated Python venvs |
+| **imagegen MCP** | Image-generation tool for Crush/Copilot (Office authoring is a skill, not MCP) | Isolated Python venv |
 
-### Models — RTX 5090 (~46 GB disk)
+### Models — RTX 5090 (~100 GB disk)
 
-| Model | Tag | Size | Task |
-|-------|-----|------|------|
-| GLM-4.7-Flash 30B MoE | `glm-4.7-flash` | 17 GB | Heavy coding, tech docs, creative, Office (202k ctx) |
-| Qwen3 14B | `qwen3:14b` | 9 GB | Light coding |
-| DeepSeek-R1 32B | `deepseek-r1:32b` | 19 GB | Code review, reasoning |
+| Model | Launcher alias | Base tag | Task |
+|-------|----------------|----------|------|
+| Qwen3.6 27B (+MTP) | `qwen36-27b-212k` | `hf.co/unsloth/Qwen3.6-27B-MTP-GGUF:Q4_K_M` | Heavy coding (default), tech docs, creative |
+| Qwen3.6 35B-A3B MoE | `qwen36-35b-256k` | `qwen3.6:35b` | Heavy coding / multimodal |
+| Gemma 4 31B dense | `gemma4-31b-128k` | `gemma4:31b` | Heavy coding / general |
+| Qwen3-Coder 30B-A3B | `qwen3coder-144k` | `qwen3-coder:30b` | Light coding / code review |
+| GLM-4.7-Flash 30B MoE | `glm47-flash-198k` | `glm-4.7-flash` | Agentic / all MCP+tools / Office authoring |
+| Qwen3 8B | `qwen3:8b` | `qwen3:8b` | Image-gen companion |
 
 ## Install
 
@@ -40,7 +43,7 @@ cd local-llm\windows
 .\install-windows.ps1 -Help
 ```
 
-> **Note:** The default 5090 profile downloads ~46GB of models. Use `-ModelPath` to store them on a fast secondary drive (SSD/NVMe) instead of filling your OS drive. The script sets `OLLAMA_MODELS` environment variable and restarts Ollama automatically.
+> **Note:** The default 5090 roster downloads ~100GB of models. Use `-ModelPath` to store them on a fast secondary drive (SSD/NVMe) instead of filling your OS drive. The script sets `OLLAMA_MODELS` environment variable and restarts Ollama automatically.
 
 ### Install Options
 
@@ -70,7 +73,7 @@ Provider tokens: `local` = local Ollama · `server` = CachyOS vLLM server.
 
 Config: `~/.config/crush/crush.json` (created by installer)
 - **Models** — `large` and `small` for Crush's internal routing
-- **MCP** — Word and PowerPoint servers (auto-configured)
+- **MCP** — imagegen server (auto-configured); Office authoring uses the `office` skill (python-docx/python-pptx/openpyxl via `uv run`)
 - **Providers** — Local Ollama is default; add API keys for cloud fallback
 
 Cloud fallback (set environment variables):
@@ -87,10 +90,13 @@ The `copilot-local` launcher reads `COPILOT_LOCAL_PROFILE` env var (set by insta
 
 Override defaults by editing `config/ollama-models.txt`:
 ```text
-# One tag per line
+# One base library tag per line (not launcher aliases)
+hf.co/unsloth/Qwen3.6-27B-MTP-GGUF:Q4_K_M
+qwen3.6:35b
+gemma4:31b
+qwen3-coder:30b
 glm-4.7-flash
-qwen3:14b
-deepseek-r1:32b
+qwen3:8b
 ```
 
 ### Image Generation
@@ -104,7 +110,7 @@ The image gen service uses a Python venv at `%LOCALAPPDATA%\ai-tools\imagegen`. 
 ollama list
 
 # 2. Inference works
-ollama run qwen3:14b "Say hello in one sentence"
+ollama run qwen3:8b "Say hello in one sentence"
 
 # 3. Crush connects
 crush run "Say hello"
@@ -112,7 +118,7 @@ crush run "Say hello"
 # 4. Copilot CLI launcher
 copilot-local
 
-# 5. MCP servers configured
+# 5. MCP server (imagegen) configured
 crush --debug run "list your tools" 2>&1 | findstr mcp_
 
 # 6. Image generation API
@@ -125,25 +131,25 @@ curl http://localhost:8001/health
 
 ```
 copilot-local                    # Interactive task picker
-copilot-local glm-4.7-flash     # Skip picker, use specific model
+copilot-local qwen36-27b-212k   # Skip picker, use specific model
 ```
 
 **Task picker (RTX 5090):**
 ```
-  [1] Heavy coding        (glm-4.7-flash)
-  [2] Light coding        (qwen3:14b)
-  [3] Code review         (deepseek-r1:32b)
-  [4] Technical docs      (glm-4.7-flash)
-  [5] Creative writing    (glm-4.7-flash)
-  [6] Office documents    (glm-4.7-flash)
-  [7] Image generation    (HiDream-O1 — local API)
+  [1] Heavy coding        (qwen36-27b-212k)
+  [2] Light coding        (qwen3coder-144k)
+  [3] Code review         (qwen3coder-144k)
+  [4] Technical docs      (qwen36-27b-212k)
+  [5] Creative writing    (qwen36-27b-212k)
+  [6] Office documents    (glm47-flash-198k)
+  [7] Image generation    (qwen3:8b + HiDream via MCP)
 ```
 
-### Crush (MCP/Office tasks)
+### Crush (agentic tasks)
 
 ```powershell
 crush                            # Interactive session
-crush run "create a slide deck"  # One-shot with MCP tools
+crush run "create a slide deck"  # One-shot; Office docs via the office skill
 ```
 
 ### Image Generation
@@ -176,7 +182,7 @@ result = client.images.generate(prompt="a sunset over mountains", size="1024x102
 ollama list                      # Installed models
 ollama ps                        # Loaded models + VRAM
 ollama pull glm-4.7-flash        # Add a model
-ollama rm qwen2.5-coder:14b     # Remove a model
+ollama rm qwen3-coder:30b        # Remove a model
 nvidia-smi                       # GPU VRAM usage
 ```
 

--- a/local-llm/windows/ReadMe.md
+++ b/local-llm/windows/ReadMe.md
@@ -2,7 +2,7 @@
 
 Single-user AI assistant on Windows with Ollama, Crush, Copilot CLI, MCP, and local image generation.
 
-**Hardware:** RTX 5090 (32GB, default) or RTX 4090 (24GB)
+**Hardware:** RTX 5090 (32GB)
 **Inference engine:** Ollama (single-user, GGUF models)
 
 ## What Gets Installed
@@ -17,20 +17,12 @@ Single-user AI assistant on Windows with Ollama, Crush, Copilot CLI, MCP, and lo
 | **copilot-local** | Task picker launcher for Copilot CLI | `~/Documents/CLI/` + PATH |
 | **MCP servers** | Office document editing (Word, PowerPoint) | Isolated Python venvs |
 
-### Models — RTX 5090 Profile (default, ~46 GB disk)
+### Models — RTX 5090 (~46 GB disk)
 
 | Model | Tag | Size | Task |
 |-------|-----|------|------|
 | GLM-4.7-Flash 30B MoE | `glm-4.7-flash` | 17 GB | Heavy coding, tech docs, creative, Office (202k ctx) |
 | Qwen3 14B | `qwen3:14b` | 9 GB | Light coding |
-| DeepSeek-R1 32B | `deepseek-r1:32b` | 19 GB | Code review, reasoning |
-
-### Models — RTX 4090 Profile (~45 GB disk)
-
-| Model | Tag | Size | Task |
-|-------|-----|------|------|
-| GLM-4.7-Flash 30B MoE | `glm-4.7-flash` | 17 GB | Heavy coding, tech docs, creative, Office (202k ctx) |
-| Qwen2.5-Coder 14B | `qwen2.5-coder:14b` | 9 GB | Light coding |
 | DeepSeek-R1 32B | `deepseek-r1:32b` | 19 GB | Code review, reasoning |
 
 ## Install
@@ -43,9 +35,6 @@ cd local-llm\windows
 
 # RTX 5090 with secondary storage (recommended)
 .\install-windows.ps1 -ModelPath D:\OllamaModels
-
-# RTX 4090 profile
-.\install-windows.ps1 -ModelProfile Server
 
 # Show all options
 .\install-windows.ps1 -Help
@@ -66,8 +55,7 @@ Provider tokens: `local` = local Ollama · `server` = CachyOS vLLM server.
 | `-Install Client` | Client tools only — no local Ollama; targets the vLLM `server` |
 | `-Providers local,server` | Crush providers to enable (`server` = the CachyOS vLLM provider) |
 | `-DefaultProvider local\|server` | Default Crush provider |
-| `-ModelProfile Desktop` | RTX 5090 roster (default) |
-| `-ModelProfile Server` | RTX 4090 roster |
+| `-OllamaModels 5090` | RTX 5090 roster (default; the only Windows tier) |
 | `-SkipModels` | Install software only; pull models later |
 | `-ModelsOnly` | Skip software; just pull/update models |
 | `-ModelPath D:\models` | Custom model storage location |

--- a/local-llm/windows/install-windows.ps1
+++ b/local-llm/windows/install-windows.ps1
@@ -21,13 +21,13 @@
     skips all Ollama installation and model steps and targets the vLLM server
     (use -SquireServerIP if it is not 192.168.1.99).
 
-.PARAMETER ModelProfile
-    GPU/environment profile that determines which models to pull:
-      Desktop — (default) RTX 5090 (32GB). Pulls the six production models
-                (Qwen3.6 27B+MTP, Qwen3.6 35B-A3B, Gemma 4 31B, Qwen3-Coder 30B,
-                GLM-4.7-Flash, Qwen3 8B) (~100 GB) — coherent with config\crush.json.
-      Server  — RTX 4090 (24GB). Same production roster fallback (~100 GB); contexts
-                are tuned for 32GB and may spill to CPU on 24GB.
+.PARAMETER OllamaModels
+    Ollama roster GPU tier that determines which models to pull:
+      5090 — (default) RTX 5090 (32GB). Pulls the six production models
+             (Qwen3.6 27B+MTP, Qwen3.6 35B-A3B, Gemma 4 31B, Qwen3-Coder 30B,
+             GLM-4.7-Flash, Qwen3 8B) (~100 GB) — coherent with config\crush.json.
+      4090 — RTX 4090 (24GB). Same production roster fallback (~100 GB); contexts
+             are tuned for 32GB and may spill to CPU on 24GB.
     -TestProfiles installs the same roster PLUS the heavy-coding + expert-offload
     bench contenders. Ignored in Client mode.
 
@@ -71,11 +71,11 @@
     Full installation with Standard profile model pulls.
 
 .EXAMPLE
-    .\install-windows.ps1 -ModelProfile Desktop
+    .\install-windows.ps1 -OllamaModels 5090
     Full install for RTX 5090 gaming desktop (pulls larger/better models).
 
 .EXAMPLE
-    .\install-windows.ps1 -ModelProfile Server
+    .\install-windows.ps1 -OllamaModels 4090
     Full install for dedicated 4090 inference server.
 
 .EXAMPLE
@@ -117,8 +117,8 @@ param(
     [ValidateSet("", "local", "server", "squire-server")]
     [string]$DefaultProvider = "",
 
-    [ValidateSet("Desktop", "Server")]
-    [string]$ModelProfile = "Desktop",
+    [ValidateSet("4090", "5090")]
+    [string]$OllamaModels = "5090",
 
     [string]$OllamaHost,
     [string]$ModelPath,
@@ -163,8 +163,8 @@ if ($Help) {
     -DefaultProvider <p>     local | server  (default: Full->local, Client->server)
     -SquireServerIP <ip>     vLLM server address (default: 192.168.1.99)
 
-  GPU PROFILES:
-    -ModelProfile Desktop   (default) RTX 5090 (32GB) — the six production models, ~100 GB:
+  GPU TIER:
+    -OllamaModels 5090      (default) RTX 5090 (32GB) — the six production models, ~100 GB:
                               qwen36-27b-212k     Heavy coding default (Qwen3.6 27B+MTP)
                               qwen36-35b-256k     Heavy coding / multimodal (Qwen3.6 35B-A3B)
                               gemma4-31b-128k     Heavy coding / general (Gemma 4 31B)
@@ -172,7 +172,7 @@ if ($Help) {
                               glm47-flash-198k    Agentic / all MCP+tools (GLM-4.7-Flash)
                               qwen3:8b            Image-gen companion
 
-    -ModelProfile Server    RTX 4090 (24GB) — same production roster fallback (~100 GB);
+    -OllamaModels 4090      RTX 4090 (24GB) — same production roster fallback (~100 GB);
                               contexts are tuned for 32GB and may spill to CPU on 24GB.
 
   OPTIONS:
@@ -207,8 +207,8 @@ if ($Help) {
     -Help                Show this help text
 
   EXAMPLES:
-    .\install-windows.ps1                                    # Desktop profile, full install
-    .\install-windows.ps1 -ModelProfile Server -EnableLAN    # Server profile, LAN exposed
+    .\install-windows.ps1                                    # 5090 tier, full install
+    .\install-windows.ps1 -OllamaModels 4090 -EnableLAN      # 4090 tier, LAN exposed
     .\install-windows.ps1 -Mode Client                      # Profile 2: squire-only client
     .\install-windows.ps1 -Install Full                                                  # 5090: Ollama server + client (local+server)
     .\install-windows.ps1 -Install Client -Providers local,server -DefaultProvider local  # client tools, both, default local
@@ -304,12 +304,12 @@ $ProductionModels = [ordered]@{
 }
 
 $ProfileDefinitions = @{
-    "Desktop" = @{
+    "5090" = @{
         Description = "RTX 5090 (32GB) — the six production models (coherent with crush.json + launchers)"
         RequiredGB = 100
         Models = $ProductionModels
     }
-    "Server" = @{
+    "4090" = @{
         # The real model server is the CachyOS/vLLM box (install-cachyos.sh); this Windows
         # profile is a coherent fallback that mirrors the Desktop production roster. Contexts
         # are 32GB-calibrated, so on a 24GB card the larger-ctx aliases may spill to CPU.
@@ -553,7 +553,7 @@ function Get-ModelDriveLetter {
 }
 
 function Get-EffectiveModelConfig {
-    $profileKey = if ($TestProfiles) { "Desktop5090Test" } else { $ModelProfile }
+    $profileKey = if ($TestProfiles) { "Desktop5090Test" } else { $OllamaModels }
     $builtIn = $ProfileDefinitions[$profileKey]
     if ((-not $TestProfiles) -and (Test-Path $CustomModelListPath)) {
         $customModels = [ordered]@{}
@@ -578,7 +578,7 @@ function Get-EffectiveModelConfig {
         }
 
         if ($customModels.Count -eq 0) {
-            Write-Warn "Custom model list at $CustomModelListPath is empty after stripping comments. Falling back to $ModelProfile profile."
+            Write-Warn "Custom model list at $CustomModelListPath is empty after stripping comments. Falling back to $OllamaModels tier."
         } else {
             return @{
                 Models = $customModels
@@ -650,7 +650,7 @@ if (",$Providers," -notlike "*,$DefaultProvider,*") {
 $ShouldInstallSoftware = $IsClientMode -or (-not $ModelsOnly)
 $ShouldPullModels = $IsFullMode -and (-not $SkipModels)
 $EffectiveModelConfig = if ($IsFullMode) { Get-EffectiveModelConfig } else { $null }
-$ModelProfileLabel = if ($IsFullMode) { $EffectiveModelConfig.Label } else { "n/a (client mode)" }
+$ModelTierLabel = if ($IsFullMode) { $EffectiveModelConfig.Label } else { "n/a (client mode)" }
 $ResolvedModelRoot = if ($IsFullMode) { Get-ResolvedModelRoot } else { $null }
 $ModelBlobsPath = if ($IsFullMode) { Join-Path $ResolvedModelRoot "blobs\*" } else { $null }
 
@@ -666,8 +666,8 @@ if ($IsClientMode) {
     if ($SkipModels) {
         Add-NonFatalWarning "SkipModels is irrelevant in client mode because no local models are pulled."
     }
-    if ($ModelProfile -ne "Desktop") {
-        Add-NonFatalWarning "ModelProfile is ignored in client mode because no local models are pulled."
+    if ($OllamaModels -ne "5090") {
+        Add-NonFatalWarning "-OllamaModels is ignored in client mode because no local models are pulled (the client targets the vLLM server)."
     }
     if ($EnableLAN) {
         Add-NonFatalWarning "EnableLAN is ignored in client mode because Ollama is not installed locally."
@@ -688,7 +688,7 @@ if ($ShouldPullModels) {
         $freeGB = [math]::Round($drive.Free / 1GB, 1)
         $requiredGB = $EffectiveModelConfig.RequiredGB
         if ($freeGB -lt $requiredGB) {
-            Write-Warn "Only $freeGB GB free on $driveLetter. Model pulls need ~$requiredGB GB for the $ModelProfileLabel profile."
+            Write-Warn "Only $freeGB GB free on $driveLetter. Model pulls need ~$requiredGB GB for the $ModelTierLabel tier."
             Write-Warn "Consider using -SkipModels and freeing space first."
         } else {
             Write-Info "$freeGB GB free on $driveLetter — sufficient for ~$requiredGB GB of model downloads."
@@ -1542,8 +1542,8 @@ if ($script:Failures.Count -gt 0 -or $script:Warnings.Count -gt 0) {
 
 Write-Host "  Mode:" -ForegroundColor White
 Write-Host "    • $Mode" -ForegroundColor Gray
-Write-Host "  Model profile:" -ForegroundColor White
-Write-Host "    • $ModelProfileLabel" -ForegroundColor Gray
+Write-Host "  Model tier:" -ForegroundColor White
+Write-Host "    • $ModelTierLabel" -ForegroundColor Gray
 Write-Host ""
 
 if ($ShouldInstallSoftware) {

--- a/local-llm/windows/install-windows.ps1
+++ b/local-llm/windows/install-windows.ps1
@@ -28,8 +28,7 @@
              GLM-4.7-Flash, Qwen3 8B) (~100 GB) — coherent with config\crush.json.
     The Windows host is the 5090 gaming desktop; a real 24GB (4090) box runs the
     CachyOS installer, which has its own tier. -TestProfiles installs the same roster
-    PLUS the heavy-coding + expert-offload
-    bench contenders. Ignored in Client mode.
+    PLUS the heavy-coding + expert-offload bench contenders. Ignored in Client mode.
 
 .PARAMETER SquireServerIP
     IP/host of the CachyOS vLLM "Squire Server" used by the launcher Remote
@@ -306,7 +305,7 @@ $ProfileDefinitions = @{
     # contender is installed at once and exposed through the launcher [H1]-[H5] bench.
     # NOTE: base pull tags below must be validated on the box — exact Ollama tags for
     # qwen3.6:35b / gemma4:31b / glm-4.7-flash may differ at install time.
-    "Desktop5090Test" = @{
+    "Test5090" = @{
         Description = "RTX 5090 (32GB) — side-by-side model bench (~1TB model storage)"
         RequiredGB = 290
         Models = [ordered]@{
@@ -538,7 +537,7 @@ function Get-ModelDriveLetter {
 }
 
 function Get-EffectiveModelConfig {
-    $profileKey = if ($TestProfiles) { "Desktop5090Test" } else { $OllamaModels }
+    $profileKey = if ($TestProfiles) { "Test5090" } else { $OllamaModels }
     $builtIn = $ProfileDefinitions[$profileKey]
     if ((-not $TestProfiles) -and (Test-Path $CustomModelListPath)) {
         $customModels = [ordered]@{}

--- a/local-llm/windows/install-windows.ps1
+++ b/local-llm/windows/install-windows.ps1
@@ -26,9 +26,9 @@
       5090 — (default) RTX 5090 (32GB). Pulls the six production models
              (Qwen3.6 27B+MTP, Qwen3.6 35B-A3B, Gemma 4 31B, Qwen3-Coder 30B,
              GLM-4.7-Flash, Qwen3 8B) (~100 GB) — coherent with config\crush.json.
-      4090 — RTX 4090 (24GB). Same production roster fallback (~100 GB); contexts
-             are tuned for 32GB and may spill to CPU on 24GB.
-    -TestProfiles installs the same roster PLUS the heavy-coding + expert-offload
+    The Windows host is the 5090 gaming desktop; a real 24GB (4090) box runs the
+    CachyOS installer, which has its own tier. -TestProfiles installs the same roster
+    PLUS the heavy-coding + expert-offload
     bench contenders. Ignored in Client mode.
 
 .PARAMETER SquireServerIP
@@ -75,10 +75,6 @@
     Full install for RTX 5090 gaming desktop (pulls larger/better models).
 
 .EXAMPLE
-    .\install-windows.ps1 -OllamaModels 4090
-    Full install for dedicated 4090 inference server.
-
-.EXAMPLE
     .\install-windows.ps1 -Mode Client
     Client-only install (Profile 2): tools only, Crush defaults to the vLLM server (192.168.1.99).
 
@@ -117,7 +113,7 @@ param(
     [ValidateSet("", "local", "server", "squire-server")]
     [string]$DefaultProvider = "",
 
-    [ValidateSet("4090", "5090")]
+    [ValidateSet("5090")]
     [string]$OllamaModels = "5090",
 
     [string]$OllamaHost,
@@ -172,9 +168,6 @@ if ($Help) {
                               glm47-flash-198k    Agentic / all MCP+tools (GLM-4.7-Flash)
                               qwen3:8b            Image-gen companion
 
-    -OllamaModels 4090      RTX 4090 (24GB) — same production roster fallback (~100 GB);
-                              contexts are tuned for 32GB and may spill to CPU on 24GB.
-
   OPTIONS:
     -OllamaHost <url>    Optional extra remote Ollama provider (not required for Client mode)
                          Example: http://192.168.1.100:11434
@@ -208,7 +201,7 @@ if ($Help) {
 
   EXAMPLES:
     .\install-windows.ps1                                    # 5090 tier, full install
-    .\install-windows.ps1 -OllamaModels 4090 -EnableLAN      # 4090 tier, LAN exposed
+    .\install-windows.ps1 -EnableLAN                         # 5090 tier, LAN exposed
     .\install-windows.ps1 -Mode Client                      # Profile 2: squire-only client
     .\install-windows.ps1 -Install Full                                                  # 5090: Ollama server + client (local+server)
     .\install-windows.ps1 -Install Client -Providers local,server -DefaultProvider local  # client tools, both, default local
@@ -306,14 +299,6 @@ $ProductionModels = [ordered]@{
 $ProfileDefinitions = @{
     "5090" = @{
         Description = "RTX 5090 (32GB) — the six production models (coherent with crush.json + launchers)"
-        RequiredGB = 100
-        Models = $ProductionModels
-    }
-    "4090" = @{
-        # The real model server is the CachyOS/vLLM box (install-cachyos.sh); this Windows
-        # profile is a coherent fallback that mirrors the Desktop production roster. Contexts
-        # are 32GB-calibrated, so on a 24GB card the larger-ctx aliases may spill to CPU.
-        Description = "RTX 4090 (24GB) — production roster fallback (contexts tuned for 32GB; may spill on 24GB)"
         RequiredGB = 100
         Models = $ProductionModels
     }
@@ -665,9 +650,6 @@ if ($IsClientMode) {
     }
     if ($SkipModels) {
         Add-NonFatalWarning "SkipModels is irrelevant in client mode because no local models are pulled."
-    }
-    if ($OllamaModels -ne "5090") {
-        Add-NonFatalWarning "-OllamaModels is ignored in client mode because no local models are pulled (the client targets the vLLM server)."
     }
     if ($EnableLAN) {
         Add-NonFatalWarning "EnableLAN is ignored in client mode because Ollama is not installed locally."


### PR DESCRIPTION
## Summary

This PR aligns the CachyOS `local` (Ollama) installer with the Windows Ollama installer, and standardizes the GPU-tier vocabulary to an explicit `4090|5090` across both. The CachyOS vLLM `server` variant is untouched, and no already-validated model contexts change.

Two files:

- `local-llm/cachyos/install-cachyos.sh`

- `local-llm/windows/install-windows.ps1`

## Why

The CachyOS installer has two engine variants: `server` (vLLM, this repo's inference box) and `local` (Ollama, the "desktop" variant meant to mirror the Windows host). Auditing them surfaced three divergences from the intended "CachyOS desktop = same Ollama stack as Windows" model:

1. CachyOS `local` always pulled all 10 models (6 production + 4 experimental/bench), while Windows pulls the 6 production by default and gates the 4 bench models behind `-TestProfiles`. A plain CachyOS desktop install was much heavier than a plain Windows install.

2. The tier selector used inconsistent, overloaded vocabulary: CachyOS `--ollama-models 4090|5090` plus a deprecated `--model-profile desktop|server`, versus Windows `-ModelProfile Desktop|Server`. "desktop" was overloaded (an engine idea and a GPU-tier alias).

3. CachyOS emitted a misleading warning that `--ollama-models` was "ignored" in client mode, when it actually is honored whenever the client wires a `local` provider (it selects the launcher's model-alias menu so it matches the remote Ollama server's tier).

## What changed

### CachyOS `install-cachyos.sh`

- Added `--test-profiles` (default off), mirroring Windows `-TestProfiles`. A default `--install local` now pulls only the 6 production models and builds the production aliases plus task slots `[1]-[7]` and bench slots `h1-h5`. With `--test-profiles`, the 4 experimental models (North Mini Code, Nemotron Cascade 2, Ornith-1.0-35B, Qwen3-Next-80B) plus their aliases, bench slots `h6-h8`/`o2`, labels, and the Qwen3-Next ChatML template are added.

- Removed the deprecated `--model-profile desktop|server` mapping entirely. `--ollama-models 4090|5090` is now the only tier flag (no deprecated alias).

- Fixed the client-mode tier handling. The tier is honored silently for `local` installs and for `client` installs whose `--providers` includes `local` (it drives the launcher alias menu). The "no effect" warning now fires only when a tier was set explicitly and no `local` provider is wired.

Validated on-box: `bash -n` clean, and a function-level test of `populate_ollama_tier` confirms default resolves to 6 pull tags / 10 slots (`h1-h5`, no `h6-h8`/`o2`), and `--test-profiles` resolves to 10 pull tags / 14 slots, for both `4090` and `5090`.

### Windows `install-windows.ps1`

- Replaced `-ModelProfile Desktop|Server` with `-OllamaModels 4090|5090` (default `5090`), removed outright with no deprecated alias. `$ProfileDefinitions` rekeyed `Desktop -> 5090`, `Server -> 4090`. Internal `$ModelProfileLabel -> $ModelTierLabel`, and all parameter docs, examples, help text, disk-check and summary strings updated. The client-mode note is reframed (the tier is not used by the Windows client, which targets the vLLM server, not a remote Ollama).

Validated: parsed clean with PowerShell 7.4.6 `[Parser]::ParseFile`, no residual `ModelProfile` / `Desktop` / `Server` profile references.

## Behavior notes

- No change to the vLLM `server` variant, and no change to the model contexts validated in the prior image-companion/context PR (already on `main`).

- Windows `4090` currently remains a shared-context fallback (both tiers build the 5090-calibrated contexts, which "may spill on 24GB"). Making `4090` a real 24GB-safe context tier was intentionally deferred, see Windows TODO below.

## Windows TODO (for the Windows agent)

The Windows side of this PR is the vocabulary rename only, and it is parse-validated but not runtime-tested on Windows. Please verify and consider the deferred tier work:

1. Runtime-verify the rename. Confirm `install-windows.ps1` runs with `-OllamaModels 5090` (default) and `-OllamaModels 4090`, that `Get-Help .\install-windows.ps1` renders the new `-OllamaModels` parameter, and that `-TestProfiles` still resolves to the `Desktop5090Test` roster. Confirm no remaining callers pass `-ModelProfile` (CI, docs, shortcuts, scheduled tasks).

2. Decide on a real `4090` context tier (the deferred piece). Today both Windows tiers build the same 5090-calibrated alias contexts. A genuine 4090 tier needs 24GB-safe contexts. The blocker: Windows alias names embed the context (for example `qwen36-27b-212k`) and are referenced by the launchers and `config/crush.json`. A real 4090 tier therefore requires the launchers (`copilot-local.cmd`, `crush-task.ps1`) and `crush.json` to become tier-aware, which is a cross-template change. The CachyOS side already models both tiers (4090 uses `qwen36-27b-96k` / `glm47-flash-45k` style names and smaller contexts) and can serve as the reference. Evaluate whether this is worth doing for the Windows host, which is the 5090 gaming desktop in practice.

3. Confirm client-mode tier semantics. On Windows the `client` install targets the vLLM server (192.168.1.99), not a remote Ollama, so `-OllamaModels` is intentionally a no-op in client mode. Confirm this matches the intended Windows topology, or flag if a Windows client should ever present a tier-specific local-Ollama menu (which would require porting the CachyOS tier-alias config generation to Windows).

4. Optional parity check. If you do add a real 4090 tier, mirror the CachyOS `--test-profiles` production-vs-bench split exactly (production: Qwen3.6-27B-MTP, Qwen3.6-35B, Gemma 4 31B, Qwen3-Coder 30B, GLM-4.7-Flash, Qwen3 8B; experimental: North Mini Code 1.0, Nemotron Cascade 2 30B-A3B, Ornith-1.0-35B, Qwen3-Next-80B).

## Not in this PR

- No change to the vLLM server mode or the image companion.

- No real Windows 4090 context tier (deferred, see Windows TODO item 2).

- Repository model rosters remain two parallel hand-maintained lists (Bash and PowerShell); a single shared manifest is a possible future improvement but out of scope here.